### PR TITLE
Use realpath to locate relative files, add python impl

### DIFF
--- a/project/packaging.scala
+++ b/project/packaging.scala
@@ -49,7 +49,7 @@ object Packaging {
     fixedLinuxScriptDir <<= target / "linux-scripts",
     fixedUniversalScriptDir <<= target / "universal-scripts",
     linuxFixedScripts <<= (fixedScriptDir, fixedLinuxScriptDir) map fixScripts("/usr/lib/sbt/sbt-launch.jar", "/usr/share/sbt/sbt-launch-lib.bash"),
-    universalFixedScripts <<= (fixedScriptDir, fixedUniversalScriptDir) map fixScripts("\\$(dirname \\$0)/sbt-launch.jar", "\\$(dirname \\$0)/sbt-launch-lib.bash"),
+    universalFixedScripts <<= (fixedScriptDir, fixedUniversalScriptDir) map fixScripts("\\$(dirname \\$(realpath \\$0))/sbt-launch.jar", "\\$(dirname \\$(realpath \\$0))/sbt-launch-lib.bash"),
     sbtLaunchJarUrl <<= sbtVersion apply downloadUrlForVersion,
     sbtLaunchJarLocation <<= target apply (_ / "sbt-launch.jar"),
     sbtLaunchJar <<= (sbtLaunchJarUrl, sbtLaunchJarLocation) map { (uri, file) =>

--- a/src/scripts/sbt
+++ b/src/scripts/sbt
@@ -1,5 +1,25 @@
 #!/usr/bin/env bash
 
+realpath () {
+(
+  TARGET_FILE=$1
+
+  cd $(dirname $TARGET_FILE)
+  TARGET_FILE=$(basename $TARGET_FILE)
+
+  COUNT=0
+  while [ -L "$TARGET_FILE" -a $COUNT -lt 100 ]
+  do
+      TARGET_FILE=$(readlink $TARGET_FILE)
+      cd $(dirname $TARGET_FILE)
+      TARGET_FILE=$(basename $TARGET_FILE)
+      COUNT=$(($COUNT + 1))
+  done
+
+  echo $(pwd -P)/$TARGET_FILE
+)
+}
+
 . @@BASH-LIB-LOCATION@@
 
 


### PR DESCRIPTION
because Mac OSX doesn't have a realpath binary.

This solves the issue where if you symlink to sbt, it
won't be able to locate the bash library and launcher anymore.

You'd want to do that so you can symlink just sbt to /usr/local/bin
without having to put a bash library file there as well.
In particular, this is what we'd like for Mac homebrew.
