### PR TITLE
Load sbtconfig.txt in sbt shell script

### DIFF
--- a/src/windows/sbt
+++ b/src/windows/sbt
@@ -1,13 +1,17 @@
 #!/bin/sh
 # sbt launcher script for Cygwin and MSYS
+#
+# Environment:
+# JAVA_HOME - location of a JDK home dir (mandatory)
+# SBT_OPTS  - JVM options (optional)
+# Configuration:
+# sbtconfig.txt found in the SBT_HOME.
 
 if [ -z "$JAVA_HOME" ]; then
 JAVA_CMD=java
 else
 JAVA_CMD=$JAVA_HOME/bin/java
 fi
-
-JAVA_OPTS=-Xmx512M
 
 UDIR=`dirname "$0"`
 if [ -z "$MSYSTEM" ]; then
@@ -16,12 +20,16 @@ else
   WDIR=`echo "$UDIR" | sed -e 's~^/\([^/]*\)/~\1:/~'`
 fi
 
+if [ -z "$JAVA_OPTS" ]; then
+  JAVA_OPTS=$(cat "$WDIR/sbtconfig.txt" | sed -e 's/\r//g' -e 's/^#.*$//g' | sed ':a;N;$!ba;s/\n/ /g')
+fi
+
 if [ "_$TERM" = "_xterm" ]; then
   # Let the terminal handle ANSI sequences
   stty -icanon min 1 -echo > /dev/null 2>&1
-  "$JAVA_CMD" $JAVA_OPTS -Djline.terminal=jline.UnixTerminal -jar "$WDIR/sbt-launch.jar" "$@"
+  "$JAVA_CMD" $JAVA_OPTS -Djline.terminal=jline.UnixTerminal $SBT_OPTS -jar "$WDIR/sbt-launch.jar" "$@"
   stty icanon echo > /dev/null 2>&1
 else
   # Use Jansi to intercept ANSI sequences
-  "$JAVA_CMD" $JAVA_OPTS -Dsbt.log.format=true -cp "$WDIR/jansi.jar;$WDIR/sbt-launch.jar;$WDIR/classes" SbtJansiLaunch "$@"
+  "$JAVA_CMD" -Dsbt.log.format=true $JAVA_OPTS $SBT_OPTS -cp "$WDIR/jansi.jar;$WDIR/sbt-launch.jar;$WDIR/classes" SbtJansiLaunch "$@"
 fi


### PR DESCRIPTION
Review by @jsuereth

I need to leave in 5 minutes, so I had to hurry this one. It's tested briefly but needs more extensive testing. I'm not sure if setting sbt.log.format=true will affect the Xterm stuff negatively. I still think it should be in the scripts and not in sbtconfig.txt
