### PR TITLE
Replaced last usage of missing 'die' function.

### DIFF
--- a/src/scripts/sbt-launch-lib.bash
+++ b/src/scripts/sbt-launch-lib.bash
@@ -90,7 +90,8 @@ require_arg () {
   local opt="$2"
   local arg="$3"
   if [[ -z "$arg" ]] || [[ "${arg:0:1}" == "-" ]]; then
-    die "$opt requires <$type> argument"
+    echo "$opt requires <$type> argument"
+    exit 1
   fi
 }
 


### PR DESCRIPTION
This was causing the launcher to produce weird results when the jvm-debug argument was missing a port.
