### PR TITLE
Perform shell expansion when loading sbtopts files.

### DIFF
--- a/src/scripts/sbt
+++ b/src/scripts/sbt
@@ -94,7 +94,9 @@ process_my_args () {
 }
 
 loadConfigFile() {
-  cat "$1" | sed '/^\#/d'
+  for line in $(cat "$1" | sed '/^\#/d'); do
+    eval echo $line
+  done
 }
 
 # if sbtopts files exist, prepend their contents to $@ so it can be processed by this runner


### PR DESCRIPTION
This is so that tilde and variable expansion gets performed before
the sbt command line is built, otherwise options like `"-ivy ~/.ivy2"`
don't work, because the tilde is never expanded.
