### PR TITLE
Fixing exit code handling

### DIFF
--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -11,7 +11,6 @@
 
 @echo off
 set SBT_HOME=%~dp0
-set ERROR_CODE=0
 
 rem FIRST we load the config file of extra options.
 set FN=%SBT_HOME%\..\conf\sbtconfig.txt
@@ -45,10 +44,10 @@ if ERRORLEVEL 1 goto error
 goto end
 
 :error
-set ERROR_CODE=1
+@endlocal
+exit /B 1
+
 
 :end
-
 @endlocal
-
-exit /B %ERROR_CODE%
+exit /B 0


### PR DESCRIPTION
The endlocal statement will wipe out the ERROR_CODE variable, so we cannot access %ERROR_CODE% after endlocal.
