### PR TITLE
Don't pass MaxPermSize to Java 8+

### DIFF
--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -17,6 +17,7 @@ declare -a java_args
 declare -a scalac_args
 declare -a sbt_commands
 declare java_cmd=java
+declare java_version
 declare -r sbt_bin_dir="$(dirname "$(realpath "$0")")"
 declare -r sbt_home="$(dirname "$sbt_bin_dir")"
 
@@ -86,12 +87,17 @@ get_mem_opts () {
     # a ham-fisted attempt to move some memory settings in concert
     # so they need not be messed around with individually.
     local mem=${1:-1024}
-    local perm=$(( $mem / 4 ))
-    (( $perm > 256 )) || perm=256
-    (( $perm < 1024 )) || perm=1024
-    local codecache=$(( $perm / 2 ))
+    local codecache=$(( $mem / 8 ))
+    (( $codecache > 128 )) || codecache=128
+    (( $codecache < 512 )) || codecache=512
 
-    echo "-Xms${mem}m -Xmx${mem}m -XX:MaxPermSize=${perm}m -XX:ReservedCodeCacheSize=${codecache}m"
+    local common_opts="-Xms${mem}m -Xmx${mem}m -XX:ReservedCodeCacheSize=${codecache}m"
+    if [[ "$java_version" < "1.8" ]]; then
+      local perm=$(( $codecache * 2 ))
+      echo "$common_opts -XX:MaxPermSize=${perm}m"
+    else
+      echo "$common_opts"
+    fi
   fi
 }
 
@@ -136,13 +142,15 @@ process_args () {
     residual_args=()
     process_my_args "${myargs[@]}"
   }
+
+  java_version=$("$java_cmd" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+  vlog "[process_args] java_version = '$java_version'"
 }
 
 # Detect that we have java installed.
 checkJava() {
   local required_version="$1"
   # Now check to see if it's a good enough version
-  declare -r java_version=$("$java_cmd" -version 2>&1 | awk -F '"' '/version/ {print $2}')
   if [[ "$java_version" == "" ]]; then
     echo
     echo No java installations was detected.


### PR DESCRIPTION
This change stops this annoying message being written to stderr (which can cause IntelliJ to freak):

```
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
```

See also:
https://bugs.openjdk.java.net/browse/JDK-6964458
https://github.com/sbt/sbt-native-packager/issues/203
https://github.com/typesafehub/activator/issues/422

Re-producing the warning message:

```
$ sudo update-java-alternatives -s java-8-oracle ; sbt -v about
# Executing command line:
java
-Xms1024m
-Xmx1024m
-XX:MaxPermSize=256m
-XX:ReservedCodeCacheSize=128m
-jar
/usr/share/sbt-launcher-packaging/bin/sbt-launch.jar
about

Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
```
