### PR TITLE
Remove unused variable script_dir

### DIFF
--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -6,12 +6,6 @@
 
 # TODO - Should we merge the main SBT script with this library?
 
-if test -z "$HOME"; then
-  declare -r script_dir="$(dirname $script_path)"
-else
-  declare -r script_dir="$HOME/.sbt"
-fi
-
 declare -a residual_args
 declare -a java_args
 declare -a scalac_args


### PR DESCRIPTION
This variable used to be set based on either $HOME or $script_path. However,
$script_path is no longer set, so when $HOME is unset there will be an
'dirname: missing operand' error message. $script_dir is no longer used
either, so we can safely remove it entirely.
