### PR TITLE
Fixed incorrect sbtopts lines processing

### DIFF
--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -131,7 +131,7 @@ process_my_args () {
 }
 
 loadConfigFile() {
-  for line in $(cat "$1" | sed '/^\#/d'); do
+  cat "$1" | sed '/^\#/d' | while read line; do
     eval echo $line
   done
 }


### PR DESCRIPTION
It used `for` loop which is known to work incorrectly with spaces. This commit changes it to `while read` loop. This allows more complex options to be specified in sbtopts files.

Fixes #80
