### PR TITLE
Fix debug option in sbt-launch-lib.bash to respect Java5+

### DIFF
--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -69,7 +69,7 @@ addResidual () {
   residual_args=( "${residual_args[@]}" "$1" )
 }
 addDebugger () {
-  addJava "-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=$1"
+  addJava "-agentlib:jdwp:transport=dt_socket,server=y,suspend=n,address=$1"
 }
 
 get_mem_opts () {


### PR DESCRIPTION
In sbt-launch-lib.bash, -Xdebug option is used for debugging. We should use -agentlib option for Java 5+.
