### PR TITLE
Delete unnecessary function

### DIFF
--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -202,10 +202,3 @@ run() {
   fi
   exit $exit_code
 }
-
-runAlternateBoot() {
-  local bootpropsfile="$1"
-  shift
-  addJava "-Dsbt.boot.properties=$bootpropsfile"
-  run $@
-}


### PR DESCRIPTION
The function “runAlternateBoot" in src/universal/bin/sbt-launch-lib.bash is not used. So I think this function is not necessary. 
