### PR TITLE
Fix wrong debug option

### DIFF
--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -69,7 +69,7 @@ addResidual () {
   residual_args=( "${residual_args[@]}" "$1" )
 }
 addDebugger () {
-  addJava "-agentlib:jdwp:transport=dt_socket,server=y,suspend=n,address=$1"
+  addJava "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=$1"
 }
 
 get_mem_opts () {


### PR DESCRIPTION
The debug option in  sbt-launch-lib.bash is wrong. It should be -agentlib:jdwp=transport instead of -agentlib:jdwp:transport.
