### PR TITLE
Fix for debug argument syntax

### DIFF
--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -69,7 +69,7 @@ addResidual () {
   residual_args=( "${residual_args[@]}" "$1" )
 }
 addDebugger () {
-  addJava "-agentlib:jdwp:transport=dt_socket,server=y,suspend=n,address=$1"
+  addJava "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=$1"
 }
 
 get_mem_opts () {


### PR DESCRIPTION
I was getting the following error whenever I attempted to run SBT with the option `-jvm-debug 5005`:

```
Error occurred during initialization of VM
Could not find agent library jdwp:transport on the library path, with error: libjdwp:transport.so: cannot open shared object file: No such file or directory
```

It looks like this was due to a syntax error in the  debugger flag.
