### PR TITLE
Set resource limit for ${java_cmd} -version in sbt initialisation

### DIFF
--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -133,7 +133,7 @@ process_args () {
     process_my_args "${myargs[@]}"
   }
 
-  java_version=$("$java_cmd" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+  java_version=$("$java_cmd" -Xmx512M -version 2>&1 | awk -F '"' '/version/ {print $2}')
   vlog "[process_args] java_version = '$java_version'"
 }
 


### PR DESCRIPTION
See: https://github.com/sbt/sbt/issues/1814

Java is a little anti-social and attempts to lazily allocate all
of system memory, even for simple operations such as printing out
the version. This causes sbt to fail to start in environments
where resources are limited (i.e. ulimit(1)). This setup is common
on shared infrastructure such as scientific computing clusters
where because of the resource limit not being specified sbt cannot
be used.

The limit is set to 512MB which ought to be ample and is in any case
the default from sbtconfig.txt. A better patch would use the limit
specified there but it isn't clear that that is worth the effort.