### PR TITLE
Allow to run sbt interactive mode in git for windows bash

### DIFF
--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -37,6 +37,7 @@ is_cygwin() {
   local os=$(uname -s)
   case "$os" in
     CYGWIN*) return 0 ;;
+    MINGW*) return 0 ;;
     *)  return 1 ;;
   esac
 }


### PR DESCRIPTION
Fix #95