### PR TITLE
Fixes sbt/sbt-launcher-package#81 by respecting SBT_OPTS memory settings.

### DIFF
--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -77,6 +77,8 @@ get_mem_opts () {
   # The reason is the Xms/Xmx, if they don't line up, cause errors.
   if [[ "${JAVA_OPTS}" == *-Xmx* ]] || [[ "${JAVA_OPTS}" == *-Xms* ]] || [[ "${JAVA_OPTS}" == *-XX:MaxPermSize* ]] || [[ "${JAVA_OPTS}" == *-XX:MaxMetaspaceSize* ]] || [[ "${JAVA_OPTS}" == *-XX:ReservedCodeCacheSize* ]]; then
      echo ""
+  elif [[ "${SBT_OPTS}" == *-Xmx* ]] || [[ "${SBT_OPTS}" == *-Xms* ]] || [[ "${SBT_OPTS}" == *-XX:MaxPermSize* ]] || [[ "${SBT_OPTS}" == *-XX:MaxMetaspaceSize* ]] || [[ "${SBT_OPTS}" == *-XX:ReservedCodeCacheSize* ]]; then
+     echo ""
   else
     # a ham-fisted attempt to move some memory settings in concert
     # so they need not be messed around with individually.


### PR DESCRIPTION
When SBT_OPTS includes Java memory options, prefer those settings over default values embedded in this script.