### PR TITLE
Handle SBT_OPTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,9 @@ notifications:
   email:
     - qbranch@typesafe.com
 before_install:
- - sudo apt-get update -qq
- - sudo apt-get install -qq rpm 
+  - cat /etc/hosts # optionally check the content *before*
+  - sudo hostname "$(hostname | cut -c1-63)"
+  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+  - cat /etc/hosts # optionally check the content *after*
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq rpm

--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -76,7 +76,9 @@ get_mem_opts () {
   # if we detect any of these settings in ${JAVA_OPTS} we need to NOT output our settings.
   # The reason is the Xms/Xmx, if they don't line up, cause errors.
   if [[ "${JAVA_OPTS}" == *-Xmx* ]] || [[ "${JAVA_OPTS}" == *-Xms* ]] || [[ "${JAVA_OPTS}" == *-XX:MaxPermSize* ]] || [[ "${JAVA_OPTS}" == *-XX:MaxMetaspaceSize* ]] || [[ "${JAVA_OPTS}" == *-XX:ReservedCodeCacheSize* ]]; then
-     echo ""
+    echo ""
+  elif [[ "${SBT_OPTS}" == *-Xmx* ]] || [[ "${SBT_OPTS}" == *-Xms* ]] || [[ "${SBT_OPTS}" == *-XX:MaxPermSize* ]] || [[ "${SBT_OPTS}" == *-XX:MaxMetaspaceSize* ]] || [[ "${SBT_OPTS}" == *-XX:ReservedCodeCacheSize* ]]; then
+    echo ""
   else
     # a ham-fisted attempt to move some memory settings in concert
     # so they need not be messed around with individually.


### PR DESCRIPTION
Fixes sbt/sbt-launcher-package#99 formerly known as sbt/sbt#2194.
get_mem_opts() is a bash function that generates memory related
options. This change makes it return `""` the SBT_OPTS variable
contains memory-related options already.

/review @dwijnand, @Duhemm, @jsuereth 

 