### PR TITLE
add support for .jvmopts and .java-version to Windows launcher

### DIFF
--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -22,6 +22,21 @@ FOR /F "tokens=* eol=# usebackq delims=" %%i IN ("%FN%") DO (
   set CFG_OPTS=!CFG_OPTS! !DO_NOT_REUSE_ME!
 )
 
+rem poor man's jenv (which is not available on Windows)
+IF DEFINED JAVA_HOMES (
+  IF EXIST .java-version FOR /F %%A IN (.java-version) DO (
+    SET JAVA_HOME=%JAVA_HOMES%\%%A
+    SET JDK_HOME=%JAVA_HOMES%\%%A
+  )
+)
+rem must set PATH or wrong javac is used for java projects
+IF DEFINED JAVA_HOME SET PATH=%JAVA_HOME%\bin;%PATH%
+
+rem users can set JAVA_OPTS via .jvmopts (sbt-extras style)
+IF EXIST .jvmopts FOR /F %%A IN (.jvmopts) DO (
+  SET JAVA_OPTS=%%A !JAVA_OPTS!
+)
+
 rem We use the value of the JAVACMD environment variable if defined
 set _JAVACMD=%JAVACMD%
 


### PR DESCRIPTION
Submitted subject to the disclaimer from the BSD 3 Clause License and forfeiting the Copyright notice part.

> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
