### PR TITLE
Missing quotes may cause incorrect PATH expansion

### DIFF
--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -30,7 +30,7 @@ IF DEFINED JAVA_HOMES (
   )
 )
 rem must set PATH or wrong javac is used for java projects
-IF DEFINED JAVA_HOME SET PATH=%JAVA_HOME%\bin;%PATH%
+IF DEFINED JAVA_HOME SET "PATH=%JAVA_HOME%\bin;%PATH%"
 
 rem users can set JAVA_OPTS via .jvmopts (sbt-extras style)
 IF EXIST .jvmopts FOR /F %%A IN (.jvmopts) DO (


### PR DESCRIPTION
If PATH contains ampersands etc, PATH may be
incorrectly expanded. Fixes #128