### PR TITLE
Fix Java version detection

### DIFF
--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -147,7 +147,7 @@ process_args () {
     process_my_args "${myargs[@]}"
   }
 
-  java_version=$("$java_cmd" -Xmx512M -version 2>&1 | awk -F '"' '/version/ {print $2}')
+  java_version=$("$java_cmd" -Xmx512M -version 2>&1 | sed 's/.*version "\([0-9]*\)\.\([0-9]*\)\..*"/\1.\2/; 1q')
   vlog "[process_args] java_version = '$java_version'"
 }
 


### PR DESCRIPTION
Previously awk was used to grab the full Java version such as 1.8.0_91.
While this is more accurate, 1.8.0_91 is not a number that can be compared by bash, and thus JDK8 detection logics were failing.

Fixes #135 

### before

```
$ sbt -v
[process_args] java_version = '1.8.0_91'
# Executing command line:
java
-Dfile.encoding=UTF-8
-Dfile.encoding=UTF-8
-Xms2048M
-Xmx2048M
-Xss6M
-XX:MaxPermSize=512M
-XX:ReservedCodeCacheSize=256M
-jar
/usr/local/Cellar/sbt/0.13.13/libexec/sbt-launch.jar

Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=512M; support was removed in 8.0
```

### after

```
$ sbt -v
[process_args] java_version = '1.8'
# Executing command line:
java
-Xms1024m
-Xmx1024m
-XX:ReservedCodeCacheSize=128m
-XX:MaxMetaspaceSize=256m
-Dfile.encoding=UTF-8
-jar
/usr/local/Cellar/sbt/0.13.13/libexec/sbt-launch.jar
```
