### PR TITLE
Fix java-devel dependency on rpm-based systems

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,7 @@ val root = (project in file(".")).
     rpmVendor := "lightbend",
     rpmUrl := Some("http://github.com/sbt/sbt-launcher-package"),
     rpmLicense := Some("BSD"),
-    rpmRequirements := Seq("java-devel >= 1.8", "java-devel < 1.9"),
+    rpmRequirements := Seq("java-1.8.0-devel"),
     rpmProvides := Seq("sbt"),
 
     // WINDOWS SPECIFIC


### PR DESCRIPTION
The dependency as specified won't work on Fedora 25.

The situation concerning requiring the selection of Java versions
is tricky, and is detailed at:
https://github.com/elastic/logstash/issues/6275
The conclusion of that thread is that "it is not possible to
provide a package that correctly works for users of all supported
Java packages.", meaning a dependency on either one of OpenJDK or
Oracle JDK.

Assuming the dependency is on OpenJDK, the list of metapackages
provided is listed at:
https://github.com/elastic/logstash/issues/6275#issuecomment-261356980

The dependency "java-1.8.0-devel" will be satisfied by any
revision of OpenJDK 1.8, so that is the one that is proposed
in this pull request.