### PR TITLE
Preserve quotes in system properties

### DIFF
--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -140,7 +140,7 @@ process_args () {
                  export PATH="$2/bin:$PATH" &&
                  shift 2 ;;
 
-            -D*) addJava "$1" && shift ;;
+          "-D*") addJava "$1" && shift ;;
             -J*) addJava "${1:2}" && shift ;;
               *) addResidual "$1" && shift ;;
     esac


### PR DESCRIPTION
Today you cannot have spaces in system properties:

$ sbt -Dfoo="bar baz" ...

It passes [-Dfoo=bar] and [baz] to java (see https://github.com/sbt/sbt/issues/2787).

This change allows you to do:

$ sbt "-Dfoo=bar baz"

which will pass ["-Dfoo=bar baz"]. And both of these two:

$ sbt "-Dfoo=bar"
$ sbt -Dfoo=bar

still work, passing [-Dfoo=bar].