### PR TITLE
mkdir -p

### DIFF
--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -197,7 +197,7 @@ copyRt() {
     vlog "[copyRt] java9_rt = '$java9_rt'"
     if [[ ! -f "$java9_rt" ]]; then
       echo Copying runtime jar.
-      mkdir "$java9_ext"
+      mkdir -p "$java9_ext"
       execRunner "$java_cmd" \
         ${JAVA_OPTS} \
         ${SBT_OPTS:-$default_sbt_opts} \


### PR DESCRIPTION
Fixes sbt/sbt#3005

I confirmed the fix using Docker as reported, but had to make a few modification to the image because of https://github.com/docker-library/openjdk/issues/101 and lack of rsync:

```
$ docker run -it -v ~/xxx/sbt-launcher-package/target:/opt/target  java:openjdk-9 bash

# ([[ ! -d $JAVA_HOME/conf ]] && ln -s $JAVA_HOME/lib $JAVA_HOME/conf)
# apt-get update && apt-get install -y rsync
# /opt/target/universal/sbt/bin/sbt
```

/cc @ScalaWilliam 