### PR TITLE
Make full installer optional

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@ Steps to publish
 ================
 
 ```
-$ sbt -Dsbt.build.version=1.0.0-M1
+$ sbt -Dsbt.build.version=1.0.0-M1 -Dsbt.build.offline=true
 > universal:publish
 > debian:publish
 > rpm:publish

--- a/build.sbt
+++ b/build.sbt
@@ -18,13 +18,15 @@ val sbtLaunchJarLocation = SettingKey[File]("sbt-launch-jar-location")
 val sbtLaunchJar = TaskKey[File]("sbt-launch-jar", "Resolves SBT launch jar")
 val moduleID = (organization) apply { (o) => ModuleID(o, "sbt", sbtVersionToRelease) }
 
+lazy val bintrayDebianUrl = settingKey[String]("API point for Debian packages")
+lazy val bintrayDebianExperimentalUrl = settingKey[String]("API point for Debian experimental packages")
+lazy val bintrayRpmUrl = settingKey[String]("API point for RPM packages")
+lazy val bintrayRpmExperimentalUrl = settingKey[String]("API point for RPM experimental packages")
+lazy val bintrayGenericPackagesUrl = settingKey[String]("API point for generic packages")
+lazy val bintrayTripple = settingKey[(String, String, String)]("id, url, and pattern")
+
 val bintrayLinuxPattern = "[module]/[revision]/[module]-[revision].[ext]"
 val bintrayGenericPattern = "[module]/[revision]/[module]/[revision]/[module]-[revision].[ext]"
-val bintrayDebianUrl = "https://api.bintray.com/content/sbt/debian/"
-val bintrayDebianExperimentalUrl = "https://api.bintray.com/content/sbt/debian-experimental/"
-val bintrayRpmUrl = "https://api.bintray.com/content/sbt/rpm/"
-val bintrayRpmExperimentalUrl = "https://api.bintray.com/content/sbt/rpm-experimental/"
-val bintrayGenericPackagesUrl = "https://api.bintray.com/content/sbt/native-packages/"
 val bintrayReleaseAllStaged = TaskKey[Unit]("bintray-release-all-staged", "Release all staged artifacts on bintray.")
 val windowsBuildId = settingKey[Int]("build id for Windows installer")
 
@@ -173,32 +175,41 @@ def downloadUrlForVersion(v: String) = (v split "[^\\d]" flatMap (i => catching(
   case _                             => "http://repo.typesafe.com/typesafe/ivy-releases/org.scala-tools.sbt/sbt-launch/"+v+"/sbt-launch.jar"
 }
 
-def makePublishTo(id: String, url: String, pattern: String): Setting[_] = {
-  publishTo := {
-    val resolver = Resolver.url(id, new URL(url))(Patterns(pattern))
-    Some(resolver)
-  }
-}
-
 def makePublishToForConfig(config: Configuration) = {
   val v = sbtVersionToRelease
-  val (id, url, pattern) =
-    config.name match {
-      case Debian.name if isExperimental => ("debian-experimental", bintrayDebianExperimentalUrl, bintrayLinuxPattern)
-      case Debian.name => ("debian", bintrayDebianUrl, bintrayLinuxPattern)
-      case Rpm.name if isExperimental => ("rpm-experimental", bintrayRpmExperimentalUrl, bintrayLinuxPattern)
-      case Rpm.name    => ("rpm", bintrayRpmUrl, bintrayLinuxPattern)
-      case _           => ("native-packages", bintrayGenericPackagesUrl, bintrayGenericPattern)
-    }
+
   // Add the publish to and ensure global resolvers has the resolver we just configured.
   inConfig(config)(Seq(
-    bintrayOrganization := Some("sbt"),
-    bintrayRepository := id,
+    bintrayOrganization := {
+      // offline installation exceeds 50MB file limit for OSS organization
+      if (sbtOfflineInstall) Some("lightbend")
+      else Some("sbt")
+    },
+    bintrayRepository := bintrayTripple.value._1,
     bintrayRepo := Bintray.cachedRepo(bintrayEnsureCredentials.value,
       bintrayOrganization.value,
       bintrayRepository.value),
     bintrayPackage := "sbt",
-    makePublishTo(id, url, pattern),
+
+    bintrayDebianUrl             := s"https://api.bintray.com/content/${bintrayOrganization.value.get}/debian/",
+    bintrayDebianExperimentalUrl := s"https://api.bintray.com/content/${bintrayOrganization.value.get}/debian-experimental/",
+    bintrayRpmUrl                := s"https://api.bintray.com/content/${bintrayOrganization.value.get}/rpm/",
+    bintrayRpmExperimentalUrl    := s"https://api.bintray.com/content/${bintrayOrganization.value.get}/rpm-experimental/",
+    bintrayGenericPackagesUrl    := s"https://api.bintray.com/content/${bintrayOrganization.value.get}/native-packages/",
+    bintrayTripple := {
+      config.name match {
+        case Debian.name if isExperimental => ("debian-experimental", bintrayDebianExperimentalUrl.value, bintrayLinuxPattern)
+        case Debian.name                   => ("debian", bintrayDebianUrl.value, bintrayLinuxPattern)
+        case Rpm.name if isExperimental    => ("rpm-experimental", bintrayRpmExperimentalUrl.value, bintrayLinuxPattern)
+        case Rpm.name                      => ("rpm", bintrayRpmUrl.value, bintrayLinuxPattern)
+        case _                             => ("native-packages", bintrayGenericPackagesUrl.value, bintrayGenericPattern)
+      }
+    },
+    publishTo := {
+      val (id, url, pattern) = bintrayTripple.value
+      val resolver = Resolver.url(id, new URL(url))(Patterns(pattern))
+      Some(resolver)
+    },
     bintrayReleaseAllStaged := bintrayRelease(bintrayRepo.value, bintrayPackage.value, version.value, sLog.value)
     // Uncomment to release right after publishing
     // publish <<= (publish, bintrayRepo, bintrayPackage, version, sLog) apply { (publish, bintrayRepo, bintrayPackage, version, sLog) =>

--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -159,9 +159,12 @@ process_args () {
 
 syncPreloaded() {
   [[ -f "$HOME/.sbt/preloaded/org.scala-sbt/sbt/$init_sbt_version/jars/sbt.jar" ]] || {
-    command -v rsync >/dev/null 2>&1 && {
-      mkdir -p "$HOME/.sbt/preloaded"
-      rsync -a --ignore-existing "$sbt_home/lib/local-preloaded/" "$HOME/.sbt/preloaded"
+    # lib/local-preloaded exists (This is optional)
+    [[ -f "$sbt_home/lib/local-preloaded/" ]] && {
+      command -v rsync >/dev/null 2>&1 && {
+        mkdir -p "$HOME/.sbt/preloaded"
+        rsync -a --ignore-existing "$sbt_home/lib/local-preloaded/" "$HOME/.sbt/preloaded"
+      }
     }
   }
 }

--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -160,6 +160,7 @@ process_args () {
 syncPreloaded() {
   [[ -f "$HOME/.sbt/preloaded/org.scala-sbt/sbt/$init_sbt_version/jars/sbt.jar" ]] || {
     command -v rsync >/dev/null 2>&1 && {
+      mkdir -p "$HOME/.sbt/preloaded"
       rsync -a --ignore-existing "$sbt_home/lib/local-preloaded/" "$HOME/.sbt/preloaded"
     }
   }

--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -149,8 +149,10 @@ if /I "%JAVA_VERSION%" GEQ "8" (
   if %ERRORLEVEL% equ 0 (
     echo %PRELOAD_SBT_JAR%
     if not exist %PRELOAD_SBT_JAR% (
-      echo 'about to robocopy'
-      robocopy "%SBT_HOME%\..\lib\local-preloaded\" "%UserProfile%\.sbt\preloaded"
+      if exist "%SBT_HOME%\..\lib\local-preloaded\" (
+        echo 'about to robocopy'
+        robocopy "%SBT_HOME%\..\lib\local-preloaded\" "%UserProfile%\.sbt\preloaded"
+      )
     )
   )
 )


### PR DESCRIPTION
This makes the full installer (zip that contains all JARs so installation is faster) optional to avoid the Bintray 50MB file limit on OSS accounts.

To create the full installer, run with the following option:

```
$ sbt -Dsbt.build.version=0.13.14 -Dsbt.build.offline=true
```

This will set the publishTo to Bintray Lightbend organization, instead of sbt.

Also Fixes sbt/sbt#3005