### PR TITLE
Replace realpath with something Mac compat

### DIFF
--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -12,9 +12,21 @@ declare -a scalac_args
 declare -a sbt_commands
 declare java_cmd=java
 declare java_version
-declare -r sbt_bin_dir="$(dirname "$(realpath "$0")")"
-declare -r sbt_home="$(dirname "$sbt_bin_dir")"
 declare init_sbt_version=
+
+declare SCRIPT=$0
+while [ -h "$SCRIPT" ] ; do
+  ls=$(ls -ld "$SCRIPT")
+  # Drop everything prior to ->
+  link=$(expr "$ls" : '.*-> \(.*\)$')
+  if expr "$link" : '/.*' > /dev/null; then
+    SCRIPT="$link"
+  else
+    SCRIPT=$(dirname "$SCRIPT")/"$link"
+  fi
+done
+declare -r sbt_bin_dir="$(dirname "$SCRIPT")"
+declare -r sbt_home="$(dirname "$sbt_bin_dir")"
 
 echoerr () {
   echo 1>&2 "$@"


### PR DESCRIPTION
Mac by default doesn't have realpath(1).
This replaces it with an equivalent bash script, so we can reduce script replacements on Homebrew.

Fixes #149