### PR TITLE
Workaround for brew test sbt

### DIFF
--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -193,7 +193,7 @@ checkJava() {
 }
 
 copyRt() {
-  if [[ "$java_version" > "8" ]]; then
+  if [[ "$java_version" == "9" ]]; then
     rtexport=$(rt_export_file)
     java9_ext=$("$java_cmd" ${JAVA_OPTS} ${SBT_OPTS:-$default_sbt_opts} ${java_args[@]} \
       -jar "$rtexport" --rt-ext-dir)


### PR DESCRIPTION
brew test sbt doesn't detect java version correctly. This change makes the script a bit more safer.

Fixes #150