### PR TITLE
Remove Java requirements for Debian/Ubuntu package

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,9 @@ val root = (project in file(".")).
     },
     // DEBIAN SPECIFIC
     version in Debian := sbtVersionToRelease,
-    debianPackageDependencies in Debian ++= Seq("openjdk-8-jdk", "bash (>= 3.2)"),
+    // Used to have "openjdk-8-jdk" but that doesn't work on Ubuntu 14.04 https://github.com/sbt/sbt/issues/3105
+    // before that we had java6-runtime-headless" and that was pulling in JDK9 on Ubuntu 16.04 https://github.com/sbt/sbt/issues/2931
+    debianPackageDependencies in Debian ++= Seq("bash (>= 3.2)"),
     debianPackageRecommends in Debian += "git",
     linuxPackageMappings in Debian += {
       val bd = sourceDirectory.value


### PR DESCRIPTION
Ref sbt/sbt#2931
Ref sbt/sbt#3105

Requiring `"openjdk-8-jdk"` prevents sbt 0.13.15 update on Ubuntu 14.04 LTS "Trusty Tahr."
Since there seems to be no reasonable way to depend on JDK 6, 7, or 8 without breaking some distro or use case, I'm going to remove the requirement here.