### PR TITLE
Remove carriage return characters when loading configuration files.

### DIFF
--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -135,7 +135,7 @@ process_my_args () {
 }
 
 loadConfigFile() {
-  cat "$1" | sed '/^\#/d' | while read line; do
+  cat "$1" | sed '/^\#/d;s/\r$//' | while read line; do
     eval echo $line
   done
 }


### PR DESCRIPTION
Added another sed command to remove any carriage returns that happen to be in the configuration files to fix #165.

Could have also piped to dos2unix if it is Cygwin although this seemed easier.

I haven't tested this very well. I tested the `loadConfigFile` function by itself but not actually using it to launch SBT.