### PR TITLE
Read last line of config files without EOL

### DIFF
--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -135,7 +135,8 @@ process_my_args () {
 }
 
 loadConfigFile() {
-  cat "$1" | sed '/^\#/d' | while read line; do
+  # Make sure the last line is read even if it doesn't have a terminating \n
+  cat "$1" | sed '/^\#/d' | while read -r line || [[ -n "$line" ]]; do
     eval echo $line
   done
 }


### PR DESCRIPTION
The last line in a configuration file may not have a terminating EOL character. This commit fixes the launcher script to read that line as well.

Inspiration: https://stackoverflow.com/questions/10929453/read-a-file-line-by-line-assigning-the-value-to-a-variable