### PR TITLE
Fix sbt/sbt#357 command line usage of test-only and test-quick

### DIFF
--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -154,6 +154,8 @@ process_args () {
 
           "-D*") addJava "$1" && shift ;;
             -J*) addJava "${1:2}" && shift ;;
+      test-only) addSbt "testOnly $2" && shift 2 ;;
+     test-quick) addSbt "testQuick $2" && shift 2 ;;
               *) addResidual "$1" && shift ;;
     esac
   done


### PR DESCRIPTION
Just because `sbt` has a rigid syntax doesn't mean the bash command line must be rigid.

Usage: `sbt test-only myTest` (rather than `sbt "test-only myTest"` which still works)