### PR TITLE
Fix java version detection in bash script

### DIFF
--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -157,7 +157,7 @@ process_args () {
               *) addResidual "$1" && shift ;;
     esac
   done
-  
+
   is_function_defined process_my_args && {
     myargs=("${residual_args[@]}")
     residual_args=()
@@ -165,7 +165,7 @@ process_args () {
   }
 
   ## parses 1.7, 1.8, 9, etc out of java version "1.8.0_91"
-  java_version=$("$java_cmd" -Xmx512M -version 2>&1 | sed 's/.*version "\([0-9]*\)\(\.[0-9]*\)\{0,1\}\(.*\)*"/\1\2/; 1q')
+  java_version=$("$java_cmd" -Xmx512M -version 2>&1 | grep ' version "' | sed 's/.*version "\([0-9]*\)\(\.[0-9]*\)\{0,1\}\(.*\)*"/\1\2/; 1q')
   vlog "[process_args] java_version = '$java_version'"
 }
 
@@ -265,8 +265,8 @@ run() {
     ${java_args[@]} \
     -jar "$sbt_jar" \
     "${sbt_commands[@]}" \
-    "${residual_args[@]}"  
-  
+    "${residual_args[@]}"
+
   exit_code=$?
 
   # Clean up the terminal from cygwin hacks.


### PR DESCRIPTION
`java -version` can include an extra line of output
if `_JAVA_OPTTIONS` is set.

This commit adds a grep step before sed to harden
against this possibility.

Before:
```
⚡ (export _JAVA_OPTIONS=-Dfoo.bar; java -version 2>&1 | sed 's/.*version "\([0-9]*\)\(\.[0-9]*\)\{0,1\}\(.*\)*"/\1\2/; 1q')
Picked up _JAVA_OPTIONS: -Dfoo.bar
```

After:
```
⚡ (export _JAVA_OPTIONS=-Dfoo.bar; java -version 2>&1 | grep ' version "' | sed 's/.*version "\([0-9]*\)\(\.[0-9]*\)\{0,1\}\(.*\)*"/\1\2/; 1q')
1.8
```

Fixes #170 