### PR TITLE
OS X compatible line-ending stripping

### DIFF
--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -137,7 +137,7 @@ process_my_args () {
 
 loadConfigFile() {
   # Make sure the last line is read even if it doesn't have a terminating \n
-  cat "$1" | sed '/^\#/d;s/\r$//' | while read -r line || [[ -n "$line" ]]; do
+  cat "$1" | sed $'/^\#/d;s/\r$//' | while read -r line || [[ -n "$line" ]]; do
     eval echo $line
   done
 }


### PR DESCRIPTION
BSD sed interprets sed 's/\r//' as "replace the literal letter r". A more compatible approach delegates the interpretation of this sequence to bash.

Fixes #186