### PR TITLE
"INIT_SBT_VERSION" is not automatically recognized

### DIFF
--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -53,7 +53,7 @@ rem We use the value of the JAVA_OPTS environment variable if defined, rather th
 set _JAVA_OPTS=%JAVA_OPTS%
 if "%_JAVA_OPTS%"=="" set _JAVA_OPTS=%CFG_OPTS%
 
-set INIT_SBT_VERSION=_TO_BE_REPLACED
+set INIT_SBT_VERSION=
 
 :args_loop
 if "%~1" == "" goto args_end


### PR DESCRIPTION
In the latter process checked that "INIT_SBT_VERSION" is blank. and got the default sbt version from the folder name, but it does not work due to "_ TO_BE_REPLACED".
As a result, "ROBOCOPY" is executed each time.