### PR TITLE
Set -XX:+UseParallelGC on Java 9

### DIFF
--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -117,6 +117,21 @@ get_mem_opts () {
   fi
 }
 
+get_gc_opts () {
+  local older_than_9="$(echo "$java_version < 9" | bc)"
+
+  if [[ "$older_than_9" == "1" ]]; then
+    # don't need to worry about gc
+    echo ""
+  elif [[ "${JAVA_OPTS}" =~ Use.*GC ]] || [[ "${JAVA_TOOL_OPTIONS}" =~ Use.*GC ]] || [[ "${SBT_OPTS}" =~ Use.*GC ]] ; then
+    # GC arg has been passed in - don't change
+    echo ""
+  else
+    # Java 9+ so revert to old
+    echo "-XX:+UseParallelGC"
+  fi
+}
+
 require_arg () {
   local type="$1"
   local opt="$2"
@@ -262,6 +277,7 @@ run() {
   # run sbt
   execRunner "$java_cmd" \
     $(get_mem_opts $sbt_mem) \
+    $(get_gc_opts) \
     ${JAVA_OPTS} \
     ${SBT_OPTS:-$default_sbt_opts} \
     ${java_args[@]} \

--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -1,12 +1,12 @@
 @REM SBT launcher script
-@REM 
+@REM
 @REM Environment:
 @REM JAVA_HOME - location of a JDK home dir (mandatory)
 @REM SBT_OPTS  - JVM options (optional)
 @REM Configuration:
 @REM sbtconfig.txt found in the SBT_HOME.
 
-@REM   ZOMG! We need delayed expansion to build up CFG_OPTS later 
+@REM   ZOMG! We need delayed expansion to build up CFG_OPTS later
 @setlocal enabledelayedexpansion
 
 @echo off
@@ -141,6 +141,13 @@ if /I "%JAVA_VERSION%" GEQ "9" (
     "%_JAVACMD%" %_JAVA_OPTS% %SBT_OPTS% -jar "%rtexport%" "%java9_rt%"
   )
   set _JAVA_OPTS=!_JAVA_OPTS! -Dscala.ext.dirs="%java9_ext%"
+
+  rem check to see if a GC has been set in the opts
+  echo !_JAVA_OPTS! | findstr /r "Use.*GC" >nul
+  if ERRORLEVEL 1 (
+    rem don't have a GC set - revert to old GC
+    set _JAVA_OPTS=!_JAVA_OPTS! -XX:+UseParallelGC
+  )
 )
 exit /B 0
 


### PR DESCRIPTION
This switches back to the old parallel GC if running 9+ _and_ the user hasn't set a GC.

Tested on:
* macOS 10.12
    * Java 8
    * Java 9
* Windows 10
    * Java 9

Needed for sbt/sbt#3559.