### PR TITLE
Updated required JDK version from 1.6 to 1.8 as-required by Scala 2.1…

### DIFF
--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -262,7 +262,7 @@ run() {
   argumentCount=$#
 
   # TODO - java check should be configurable...
-  checkJava "1.6"
+  checkJava "1.8"
 
   # Java 9 support
   copyRt

--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -113,7 +113,7 @@ if /I %ERRORLEVEL% EQU 0 (set JAVA_VERSION=1.5)
 exit /B 0
 
 :checkjava
-set required_version=1.6
+set required_version=1.8
 if /I "%JAVA_VERSION%" GEQ "%required_version%" (
   exit /B 0
 )


### PR DESCRIPTION
…2.x.

Fixed #193.