### PR TITLE
Ignore debug output when getting runtime jar path

### DIFF
--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -229,7 +229,7 @@ copyRt() {
   if [[ "$at_least_9" == "1" ]]; then
     rtexport=$(rt_export_file)
     java9_ext=$("$java_cmd" ${JAVA_OPTS} ${SBT_OPTS:-$default_sbt_opts} ${java_args[@]} \
-      -jar "$rtexport" --rt-ext-dir)
+      -jar "$rtexport" --rt-ext-dir | grep -v Listening)
     java9_rt=$(echo "$java9_ext/rt.jar")
     vlog "[copyRt] java9_rt = '$java9_rt'"
     if [[ ! -f "$java9_rt" ]]; then


### PR DESCRIPTION
This fixes #185.

When you use `-jvm-debug <port>` [this line](https://github.com/sbt/sbt-launcher-package/blob/v1.0.1/src/universal/bin/sbt-launch-lib.bash#L214-L215) will run something like this:
```bash
$ java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=9999 -jar /usr/share/sbt/bin/java9-rt-export.jar --rt-ext-dir
Listening for transport dt_socket at address: 9999
/home/mkurz/.sbt/0.13/java9-rt-ext-oracle_corporation_9_0_1
```
As you can see because the `-agentlib:...` param gets added the first line that will be printed is `Listening for transport dt_socket at address: 9999`. And of course because of this `java9_rt` in the [next line](https://github.com/sbt/sbt-launcher-package/blob/v1.0.1/src/universal/bin/sbt-launch-lib.bash#L216) ends up to contain that `Listening...` line where we only want it to contain the path to the runtime jar.

My fix is easy by just ignoring that `Listening...` line by inverting  `grep`.

However maybe it would be nicer if the `-agentlib:...` argument wouldn't even be passed to that command...? Opening the port (and closing it immediately afterwards again because it's a very short lived process) while an IDE is maybe already listening on it is maybe not the best idea.
I leave that up to you how to solve this however :wink: 