### PR TITLE
Fix "Error: Unable to access jarfile" on Windows + JDK 9

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,27 @@
+build: off
+
+init:
+  - git config --global core.autocrlf input
+
+install:
+  - cinst jdk8 -params 'installdir=C:\\jdk8'
+  - cinst jdk9 -version 9.0.1.11 -params 'installdir=C:\\jdk9'
+  - SET JAVA_HOME=C:\jdk8
+  - SET PATH=C:\jdk8\bin;%PATH%
+
+  - ps: |
+      Add-Type -AssemblyName System.IO.Compression.FileSystem
+      if (!(Test-Path -Path "C:\sbt" )) {
+        (new-object System.Net.WebClient).DownloadFile(
+          'https://cocl.us/sbt-0.13.16.zip',
+          'C:\sbt-bin.zip'
+        )
+        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sbt-bin.zip", "C:\sbt")
+      }
+  - SET PATH=C:\sbt\sbt\bin;%PATH%
+  - SET SBT_OPTS=-XX:MaxPermSize=2g -Xmx4g -Dfile.encoding=UTF8
+
+test_script:
+  - sbt "-Dsbt.build.version=1.0.4" universal:packageBin
+  - unzip target\universal\sbt.zip -d target\freshly-baked\
+  - citest\test.bat

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,5 +23,7 @@ install:
 
 test_script:
   - sbt "-Dsbt.build.version=1.0.4" universal:packageBin
-  - unzip target\universal\sbt.zip -d target\freshly-baked\
-  - citest\test.bat
+  - cd citest
+  - test.bat
+  - test1.bat
+  - test2.bat

--- a/citest/build.sbt
+++ b/citest/build.sbt
@@ -9,23 +9,19 @@ lazy val root = (project in file("."))
 
       println(xs)
 
-      assert(xs(0) startsWith "Copying runtime jar.")
-      // echo of jar name
-      assert(xs(2) startsWith "[info] Loading project definition")
-      assert(xs(3) startsWith "[info] Loading settings from build.sbt")
-      assert(xs(4) startsWith "[info] Set current project to Hello")
-      assert(xs(5) startsWith "[info] This is sbt")
-      assert(xs(6) startsWith "[info] The current project")
-      assert(xs(7) startsWith "[info] The current project is built against Scala 2.12.4")
+      assert(xs(0) startsWith "[info] Loading project definition")
+      assert(xs(1) startsWith "[info] Loading settings from build.sbt")
+      assert(xs(2) startsWith "[info] Set current project to Hello")
+      assert(xs(3) startsWith "[info] This is sbt")
+      assert(xs(4) startsWith "[info] The current project")
+      assert(xs(5) startsWith "[info] The current project is built against Scala 2.12.4")
 
       val ys = IO.readLines(file("err.txt")).toVector
 
       println(ys)
 
-      assert(ys.size == 4)
-      assert(ys(0) startsWith "Error: Unable to access jarfile")
-      assert(ys(1) startsWith "The filename, directory name, or volume label syntax is incorrect.")
-      assert(ys(2) startsWith "Error: Unable to access jarfile")
-      assert(ys(3) startsWith "Java HotSpot(TM) 64-Bit Server VM warning")
+      assert(ys.size == 2)
+      assert(ys(0) startsWith "Java HotSpot(TM) 64-Bit Server VM warning")
+      assert(ys(1) startsWith "Java HotSpot(TM) 64-Bit Server VM warning")
     }
   )

--- a/citest/build.sbt
+++ b/citest/build.sbt
@@ -1,0 +1,31 @@
+lazy val check = taskKey[Unit]("")
+
+lazy val root = (project in file("."))
+  .settings(
+    scalaVersion := "2.12.4",
+    name := "Hello",
+    check := {
+      val xs = IO.readLines(file("output.txt")).toVector
+
+      println(xs)
+
+      assert(xs(0) startsWith "Copying runtime jar.")
+      // echo of jar name
+      assert(xs(2) startsWith "[info] Loading project definition")
+      assert(xs(3) startsWith "[info] Loading settings from build.sbt")
+      assert(xs(4) startsWith "[info] Set current project to Hello")
+      assert(xs(5) startsWith "[info] This is sbt")
+      assert(xs(6) startsWith "[info] The current project")
+      assert(xs(7) startsWith "[info] The current project is built against Scala 2.12.4")
+
+      val ys = IO.readLines(file("err.txt")).toVector
+
+      println(ys)
+
+      assert(ys.size == 4)
+      assert(ys(0) startsWith "Error: Unable to access jarfile")
+      assert(ys(1) startsWith "The filename, directory name, or volume label syntax is incorrect.")
+      assert(ys(2) startsWith "Error: Unable to access jarfile")
+      assert(ys(3) startsWith "Java HotSpot(TM) 64-Bit Server VM warning")
+    }
+  )

--- a/citest/project/build.properties
+++ b/citest/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.0.4

--- a/citest/test.bat
+++ b/citest/test.bat
@@ -1,0 +1,6 @@
+cd "%~dp0"
+
+SET JAVA_HOME=C:\jdk9
+SET PATH=C:\jdk9\bin;%PATH%
+
+"..\target\freshly-baked\sbt\bin\sbt" about

--- a/citest/test1.bat
+++ b/citest/test1.bat
@@ -1,16 +1,11 @@
 @echo on
 
-cd "%~dp0"
-
-mkdir freshly-baked
-unzip ..\target\universal\sbt.zip -d freshly-baked
-
 SETLOCAL
 
 SET JAVA_HOME=C:\jdk9
 SET PATH=C:\jdk9\bin;%PATH%
 SET SBT_OPTS=-Xmx4g -Dfile.encoding=UTF8
 
-"freshly-baked\sbt\bin\sbt" about
+"freshly-baked\sbt\bin\sbt" about 1> output.txt 2> err.txt
 
 ENDLOCAL

--- a/citest/test2.bat
+++ b/citest/test2.bat
@@ -1,16 +1,11 @@
 @echo on
 
-cd "%~dp0"
-
-mkdir freshly-baked
-unzip ..\target\universal\sbt.zip -d freshly-baked
-
 SETLOCAL
 
 SET JAVA_HOME=C:\jdk9
 SET PATH=C:\jdk9\bin;%PATH%
 SET SBT_OPTS=-Xmx4g -Dfile.encoding=UTF8
 
-"freshly-baked\sbt\bin\sbt" about
+"freshly-baked\sbt\bin\sbt" check
 
 ENDLOCAL

--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -131,16 +131,15 @@ exit /B 1
 if /I "%JAVA_VERSION%" GEQ "9" (
   set rtexport="%SBT_HOME%java9-rt-export.jar"
 
-  "%_JAVACMD%" %_JAVA_OPTS% %SBT_OPTS% -jar "%rtexport%" --rt-ext-dir > "%TEMP%.\rtext.txt"
+  "%_JAVACMD%" %_JAVA_OPTS% %SBT_OPTS% -jar "!rtexport!" --rt-ext-dir > "%TEMP%.\rtext.txt"
   set /p java9_ext= < "%TEMP%.\rtext.txt"
-  set java9_rt=%java9_ext%\rt.jar
+  set java9_rt=!java9_ext!\rt.jar
 
-  if not exist "%java9_rt%" (
-    echo Copying runtime jar.
-    mkdir "%java9_ext%"
-    "%_JAVACMD%" %_JAVA_OPTS% %SBT_OPTS% -jar "%rtexport%" "%java9_rt%"
+  if not exist "!java9_rt!" (
+    mkdir "!java9_ext!"
+    "%_JAVACMD%" %_JAVA_OPTS% %SBT_OPTS% -jar "!rtexport!" "!java9_rt!"
   )
-  set _JAVA_OPTS=!_JAVA_OPTS! -Dscala.ext.dirs="%java9_ext%"
+  set _JAVA_OPTS=!_JAVA_OPTS! -Dscala.ext.dirs="!java9_ext!"
 
   rem check to see if a GC has been set in the opts
   echo !_JAVA_OPTS! | findstr /r "Use.*GC" >nul
@@ -162,7 +161,7 @@ set PRELOAD_SBT_JAR="%UserProfile%\.sbt\preloaded\org.scala-sbt\sbt\%INIT_SBT_VE
 if /I "%JAVA_VERSION%" GEQ "1.8" (
   where robocopy >nul 2>nul
   if %ERRORLEVEL% equ 0 (
-    echo %PRELOAD_SBT_JAR%
+    REM echo %PRELOAD_SBT_JAR%
     if not exist %PRELOAD_SBT_JAR% (
       if exist "%SBT_HOME%\..\lib\local-preloaded\" (
         echo 'about to robocopy'


### PR DESCRIPTION
Fixes sbt/sbt#3804

This adds a basic AppVeyor test that packages a zip, unzips it, and runs a build. Inside the batch `if (...)`, it seems like bunch of variables were set to blank. Using delayed expansion seems to fix this. This is confirmed by the newly added test.