### PR TITLE
remove invisible carriage-return appended to java_version under cygwin

### DIFF
--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -180,7 +180,7 @@ process_args () {
   }
 
   ## parses 1.7, 1.8, 9, etc out of java version "1.8.0_91"
-  java_version=$("$java_cmd" -Xms128M -Xmx512M -version 2>&1 | grep ' version "' | sed 's/.*version "\([0-9]*\)\(\.[0-9]*\)\{0,1\}\(.*\)*"/\1\2/; 1q')
+  java_version=$("$java_cmd" -Xms128M -Xmx512M -version 2>&1 | tr '\r' '\n' | grep ' version "' | sed 's/.*version "\([0-9]*\)\(\.[0-9]*\)\{0,1\}\(.*\)*"/\1\2/; 1q')
   vlog "[process_args] java_version = '$java_version'"
 }
 


### PR DESCRIPTION
(See the guidelines for contributing, linked above)

## steps
launch sbt from a cygwin bash session with windows java version 1.8 in PATH


## problem
symptom with current code is to exit with complaint that java version 1.8 is not new enough

The fix is to modify line 183 of sbt-launch-lib.bash to convert carriage returns to newlines, e.g.:
```
tr '\r' '\n'
```

current code:
```
  java_version=$("$java_cmd" -Xmx512M -version 2>&1 |                grep ' version "' | sed 's/.*version "\([0-9]*\)\(\.[0-9]*\)\{0,1\}\(.*\)*"/\1\2/; 1q')
```
fixed code:
```
  java_version=$("$java_cmd" -Xmx512M -version 2>&1 | tr '\r' '\n' | grep ' version "' | sed 's/.*version "\([0-9]*\)\(\.[0-9]*\)\{0,1\}\(.*\)*"/\1\2/; 1q')
```

line 183 of sbt-launch-lib.bash needs to convert '\r' to '\n' before grepping for 'version'

## expectation
should launch without complaining about java version 1.8


## notes

sbt version: 1.0.3

  