### PR TITLE
Fix "was unexpected at this time."

### DIFF
--- a/citest/build.sbt
+++ b/citest/build.sbt
@@ -16,12 +16,9 @@ lazy val root = (project in file("."))
       assert(xs(4) startsWith "[info] The current project")
       assert(xs(5) startsWith "[info] The current project is built against Scala 2.12.4")
 
-      val ys = IO.readLines(file("err.txt")).toVector
+      val ys = IO.readLines(file("err.txt")).toVector.distinct
 
-      println(ys)
-
-      assert(ys.size == 2)
+      assert(ys.size == 1, s"ys has more than one item: $ys")
       assert(ys(0) startsWith "Java HotSpot(TM) 64-Bit Server VM warning")
-      assert(ys(1) startsWith "Java HotSpot(TM) 64-Bit Server VM warning")
     }
   )

--- a/citest/test.bat
+++ b/citest/test.bat
@@ -7,6 +7,8 @@ unzip ..\target\universal\sbt.zip -d freshly-baked
 
 SETLOCAL
 
+"freshly-baked\sbt\bin\sbt" about
+
 SET JAVA_HOME=C:\jdk9
 SET PATH=C:\jdk9\bin;%PATH%
 SET SBT_OPTS=-Xmx4g -Dfile.encoding=UTF8

--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -129,7 +129,7 @@ exit /B 1
 
 :copyrt
 if /I "%JAVA_VERSION%" GEQ "9" (
-  set rtexport=%SBT_HOME%java9-rt-export.jar
+  set rtexport=!SBT_HOME!java9-rt-export.jar
 
   "%_JAVACMD%" %_JAVA_OPTS% %SBT_OPTS% -jar "!rtexport!" --rt-ext-dir > "%TEMP%.\rtext.txt"
   set /p java9_ext= < "%TEMP%.\rtext.txt"


### PR DESCRIPTION
Fixes #206

When I use unzipped sbt.bat it seems to runs ok, but using the msi installer version, `rtexport` variable seems to expand and causes:

```
\sbt\bin\java9-rt-export.jar was unexpected at this time.
```
  