### PR TITLE
Unfreeze jdk9 appveyor package version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ init:
 
 install:
   - cinst jdk8 -params 'installdir=C:\\jdk8'
-  - cinst jdk9 -params 'installdir=C:\\jdk9'
+  - cinst jdk9 -version 9.0.4.11 -params 'installdir=C:\\jdk9'
   - SET JAVA_HOME=C:\jdk8
   - SET PATH=C:\jdk8\bin;%PATH%
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ init:
 
 install:
   - cinst jdk8 -params 'installdir=C:\\jdk8'
-  - cinst jdk9 -version 9.0.1.11 -params 'installdir=C:\\jdk9'
+  - cinst jdk9 -params 'installdir=C:\\jdk9'
   - SET JAVA_HOME=C:\jdk8
   - SET PATH=C:\jdk8\bin;%PATH%
 


### PR DESCRIPTION
So it gets the new package version which has the updated download links. However, the new package version needs to be approved first: https://chocolatey.org/packages/jdk9