### PR TITLE
Whitelist java9-rt-ext- output in rt export process

### DIFF
--- a/java9-rt-export/src/main/java/io/github/retronym/java9rtexport/Export.java
+++ b/java9-rt-export/src/main/java/io/github/retronym/java9rtexport/Export.java
@@ -29,6 +29,10 @@ public class Export {
             if (destination.equals("--rt-ext-dir")) {
                 String v = System.getProperty("java.vendor") + "_" + System.getProperty("java.version");
                 v = v.replaceAll("\\W", "_").toLowerCase();
+                /*
+                 * The launch script greps for output starting with "java9-rt-ext-" so changing this
+                 * string will require changing the grep command in sbt-launch-lib.bash.
+                 */
                 Path rtExtDir = Paths.get(globalBase, "java9-rt-ext-" + v);
                 System.out.println(rtExtDir.toString());
                 System.exit(0);

--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -234,8 +234,9 @@ copyRt() {
   local at_least_9="$(expr $java_version ">=" 9)"
   if [[ "$at_least_9" == "1" ]]; then
     rtexport=$(rt_export_file)
+    # The grep for java9-rt-ext- matches the filename prefix printed in Export.java
     java9_ext=$("$java_cmd" ${JAVA_OPTS} ${SBT_OPTS:-$default_sbt_opts} ${java_args[@]} \
-      -jar "$rtexport" --rt-ext-dir | grep -v Listening)
+      -jar "$rtexport" --rt-ext-dir | grep java9-rt-ext-)
     java9_rt=$(echo "$java9_ext/rt.jar")
     vlog "[copyRt] java9_rt = '$java9_rt'"
     if [[ ! -f "$java9_rt" ]]; then


### PR DESCRIPTION
If -verbose:gc is set, there can be gc log output in this process that
prevents the directory from being properly extracted. Rather than
blacklist possible output strings, I think it makes more sense to
whitelist the specific output line that we're looking for.