### PR TITLE
Exit if the current dir is definitely not an sbt dir and neither `-sbt-create` nor `new` was given

### DIFF
--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -127,12 +127,31 @@ process_my_args () {
 
     -sbt-create) sbt_create=true && shift ;;
 
+            new) sbt_new=true && addResidual "$1" && shift ;;
+
               *) addResidual "$1" && shift ;;
     esac
   done
   
   # Now, ensure sbt version is used.
   [[ "${sbt_version}XXX" != "XXX" ]] && addJava "-Dsbt.version=$sbt_version" 
+
+  # Confirm a user's intent if the current directory does not look like an sbt
+  # top-level directory and neither the -sbt-create option nor the "new"
+  # command was given.
+  [[ -f ./build.sbt || -d ./project || -n "$sbt_create" || -n "$sbt_new" ]] || {
+    echo "[warn] Neither build.sbt nor a 'project' directory in the current directory: $(pwd)"
+    while true; do
+      echo 'c) continue'
+      echo 'q) quit'
+
+      read -p '? ' || exit 1
+      case "$REPLY" in
+        c|C) break ;;
+        q|Q) exit 1 ;;
+      esac
+    done
+  }
 }
 
 loadConfigFile() {


### PR DESCRIPTION
This restores what has been omitted accidentally during commit 55e0dfdc65440cb02627ccbb290a9afba211a9dc, taking the `new` command into account.

In order to test this modification, you may need to turn `-sbt-create` off in your `/etc/sbtops` file, which is turned on by default: https://github.com/sbt/sbt-launcher-package/blob/d16ab1abd14656902a4b44555c550057e5c125bf/src/universal/conf/sbtopts#L12

Fixes #212