### PR TITLE
Fix quotes in sbt.bat

### DIFF
--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -166,7 +166,7 @@ if /I "%JAVA_VERSION%" GEQ "1.8" (
     REM echo %PRELOAD_SBT_JAR%
     if not exist %PRELOAD_SBT_JAR% (
       if exist "%SBT_HOME%\..\lib\local-preloaded\" (
-        echo 'about to robocopy'
+        echo "about to robocopy"
         robocopy "%SBT_HOME%\..\lib\local-preloaded" "%UserProfile%\.sbt\preloaded" /E
       )
     )


### PR DESCRIPTION
cmd/bat files use double quotes instead of single ones. This PR changes from:

```console
$ echo 'about to robocopy'
'about to robocopy'
```

to:

```console
$ echo "about to robocopy"
about to robocopy
```
