### PR TITLE
forward -debug to sbt

### DIFF
--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -177,7 +177,7 @@ process_args () {
     case "$1" in
        -h|-help) usage; exit 1 ;;
     -v|-verbose) verbose=1 && shift ;;
-      -d|-debug) debug=1 && shift ;;
+      -d|-debug) debug=1 && addSbt "-debug" && shift ;;
 
            -ivy) require_arg path "$1" "$2" && addJava "-Dsbt.ivy.home=$2" && shift 2 ;;
            -mem) require_arg integer "$1" "$2" && sbt_mem="$2" && shift 2 ;;


### PR DESCRIPTION
`-debug` is a legitimate command since 0.13.13, but it's been impossible to use it because Bash eats it. This allows log level to be set to debug level. (similar to `-warn` setting to warn level)

Ref https://github.com/sbt/sbt/pull/2742
