### PR TITLE
Java version detection broken on windows

### DIFF
--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -102,7 +102,7 @@ goto :eof
 rem Parses x out of 1.x; for example 8 out of java version 1.8.0_xx
 rem Otherwise, parses the major version; 9 out of java version 9-ea
 set JAVA_VERSION=0
-for /f "tokens=3" %%g in ('%_JAVACMD% -Xms32M -Xmx32M -version 2^>^&1 ^| findstr /i "version"') do (
+for /f "tokens=3" %%g in ('"%_JAVACMD%" -Xms32M -Xmx32M -version 2^>^&1 ^| findstr /i version') do (
   set JAVA_VERSION=%%g
 )
 set JAVA_VERSION=%JAVA_VERSION:"=%


### PR DESCRIPTION
- Java version detection broken, when path to JDK contains spaces.
  Allways outputs:
    sbt requires at least version 6+, you have
    version 0

- the quoted version word for findstr doesn't seem to work in the for-command statement, quotes not needed for a single word.