### PR TITLE
Fix rsync source path designation in preloaded; fixes #246

### DIFF
--- a/citest/test.sh
+++ b/citest/test.sh
@@ -17,15 +17,20 @@ export SBT_OPTS="-Dfile.encoding=UTF-8 -Xms2048M -Xmx2048M -Xss2M -XX:MaxPermSiz
 
 ./freshly-baked/sbt/bin/sbt about run
 
+fail() {
+    echo "$@" >&2
+    exit 1
+}
+
 env HOME=./target/home1 ./freshly-baked/sbt/bin/sbt about
-test -d ./target/home1/.sbt/preloaded || echo "expected to find preloaded in ./target/home1/.sbt"
+test -d ./target/home1/.sbt/preloaded/org.scala-sbt || fail "expected to find preloaded in ./target/home1/.sbt"
 
 env HOME=./target/home2 ./freshly-baked/sbt/bin/sbt -sbt-dir ./target/home2/alternate-sbt about
-test -d ./target/home2/alternate-sbt/preloaded || echo "expected to find preloaded in ./target/home2/alternate-sbt"
+test -d ./target/home2/alternate-sbt/preloaded/org.scala-sbt || fail "expected to find preloaded in ./target/home2/alternate-sbt"
 
 env HOME=./target/home3 ./freshly-baked/sbt/bin/sbt -J-Dsbt.preloaded=./target/home3/alternate-preloaded about
-test -d ./target/home3/alternate-preloaded || echo "expected to find preloaded in ./target/home3/alternate-preloaded"
+test -d ./target/home3/alternate-preloaded/org.scala-sbt || fail "expected to find preloaded in ./target/home3/alternate-preloaded"
 
 env HOME=./target/home4 ./freshly-baked/sbt/bin/sbt -J-Dsbt.global.base=./target/home4/global-base about
-test -d ./target/home4/global-base || echo "expected to find preloaded in ./target/home4/global-base"
+test -d ./target/home4/global-base/preloaded/org.scala-sbt || fail "expected to find preloaded in ./target/home4/global-base"
 

--- a/src/universal/bin/sbt-launch-lib.bash
+++ b/src/universal/bin/sbt-launch-lib.bash
@@ -249,7 +249,7 @@ getPreloaded() {
 }
 
 syncPreloaded() {
-  local source_preloaded="$sbt_home/lib/local-preloaded"
+  local source_preloaded="$sbt_home/lib/local-preloaded/"
   local target_preloaded="$(getPreloaded)"
   if [[ "$init_sbt_version" == "" ]]; then
     # FIXME: better $init_sbt_version detection


### PR DESCRIPTION
Here’s hoping I didn’t screw this up a third time.