### PR TITLE
fix #248. 

### DIFF
--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -104,15 +104,15 @@ if not exist build.sbt (
   )
 )
 
-if defined JVM_DEBUG_PORT (
-  set _JAVA_OPTS=!_JAVA_OPTS! -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=!JVM_DEBUG_PORT!
-)
-
 call :process
 
 call :checkjava
 
 call :copyrt
+
+if defined JVM_DEBUG_PORT (
+  set _JAVA_OPTS=!_JAVA_OPTS! -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=!JVM_DEBUG_PORT!
+)
 
 call :sync_preloaded
 


### PR DESCRIPTION
fix #248. Move setting JVM's debug option after executing `:copyrt` label, in order to avoid unintended debug string written to `rtext.txt`