### PR TITLE
gzip deb so we can publish to Bintray

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,8 @@ val root = (project in file(".")).
     },
     debianChangelog in Debian := { Some(sourceDirectory.value / "debian" / "changelog") },
     addPackage(Debian, packageBin in Debian, "deb"),
-    
+    debianNativeBuildOptions in Debian := Seq("-Zgzip", "-z3"),
+
     // RPM SPECIFIC
     rpmRelease := "0",
     version in Rpm := {


### PR DESCRIPTION
Bintray started rejecting deb file that's not compressed, so for sbt 1.2.8 I had to compress this using gzip.
