### PR TITLE
unset immediatly exit flag (set +e) in launch script

### DIFF
--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set +e
 
 ###  ------------------------------- ###
 ###  Helper methods for BASH scripts ###


### PR DESCRIPTION
When the sbt launcher script is called from a bash session where the immediate exit flag is set and that option is exported then the launcher scripts terminates unintentionally. In order to reproduce:

```
bash> set -e
bash> export SHELLOPTS
base> sbt ...
```
The reason is that the launcher script contains commands that fail but that should not terminate the script. For example if debugging is not enabled then the `dlog` function has a failure return code:

```
dlog () {
  [[ $debug ]] && echoerr "$@"
}
```

An easy way to fix that behaviour is clearing the immediate exit flag in the launcher script by calling

```
set +e
```
