### PR TITLE
Reinstate realpath

### DIFF
--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -17,6 +17,33 @@ declare -r default_java_opts="-Dfile.encoding=UTF-8"
 ###  Helper methods for BASH scripts ###
 ###  ------------------------------- ###
 
+# Bash reimplementation of realpath to return the absolute path
+realpathish () {
+(
+  TARGET_FILE="$1"
+  FIX_CYGPATH="$2"
+
+  cd "$(dirname "$TARGET_FILE")"
+  TARGET_FILE=$(basename "$TARGET_FILE")
+
+  COUNT=0
+  while [ -L "$TARGET_FILE" -a $COUNT -lt 100 ]
+  do
+    TARGET_FILE=$(readlink "$TARGET_FILE")
+    cd "$(dirname "$TARGET_FILE")"
+    TARGET_FILE=$(basename "$TARGET_FILE")
+    COUNT=$(($COUNT + 1))
+  done
+
+  # make sure we grab the actual windows path, instead of cygwin's path.
+  if [[ "x$FIX_CYGPATH" != "x" ]]; then
+    echo "$(cygwinpath "$(pwd -P)/$TARGET_FILE")"
+  else
+    echo "$(pwd -P)/$TARGET_FILE"
+  fi
+)
+}
+
 # Uses uname to detect if we're in the odd cygwin environment.
 is_cygwin() {
   local os=$(uname -s)
@@ -43,18 +70,7 @@ cygwinpath() {
 }
 
 
-declare SCRIPT=$0
-while [ -h "$SCRIPT" ] ; do
-  ls=$(ls -ld "$SCRIPT")
-  # Drop everything prior to ->
-  link=$(expr "$ls" : '.*-> \(.*\)$')
-  if expr "$link" : '/.*' > /dev/null; then
-    SCRIPT="$link"
-  else
-    SCRIPT=$(dirname "$SCRIPT")/"$link"
-  fi
-done
-declare -r sbt_bin_dir="$(dirname "$SCRIPT")"
+declare -r sbt_bin_dir="$(dirname "$(realpathish "$0")")"
 declare -r sbt_home="$(dirname "$sbt_bin_dir")"
 
 echoerr () {


### PR DESCRIPTION
Fixes #269
Ref #149

There were two implementations of `realpath`-like things the scripts. One in `sbt` called `realpath` contributed in #27, and another using ls in sbt-launch-lib.bash that I added in #155 because at some point I got confused by the fact macOS doesn't have [realpath(1)](https://linux.die.net/man/1/realpath).

In #257 `sbt` and `sbt-launcher-lib.bash` were merged and the emulated `realpath` was removed.

@dcsobral noticed this and raised #269. This commit reinstates the emulated `realpath` as `realpathish` to avoid the future confusion, and removes the inferior version that uses `ls`.
