### PR TITLE
Add --java-home and fix JVM_DEBUG in sbt.bat

### DIFF
--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -67,6 +67,9 @@ if "%~1" == "" goto args_end
 if "%~1" == "-jvm-debug" set JVM_DEBUG=true
 if "%~1" == "--jvm-debug" set JVM_DEBUG=true
 
+if "%~1" == "-java-home" set SET_JAVA_HOME=true
+if "%~1" == "--java-home" set SET_JAVA_HOME=true
+
 if "%JVM_DEBUG%" == "true" (
   set /a JVM_DEBUG_PORT=5005 2>nul >nul
 ) else if "!JVM_DEBUG!" == "true" (
@@ -79,6 +82,24 @@ if "%JVM_DEBUG%" == "true" (
   set SBT_ARGS=!SBT_ARGS! %1
 ) else (
   set SBT_ARGS=!SBT_ARGS! %1
+)
+
+if "%SET_JAVA_HOME%" == "true" (
+  set SET_JAVA_HOME=
+  if NOT "%~2" == "" (
+    if exist "%~2\bin\java.exe" (
+      set _JAVACMD="%~2\bin\java.exe"
+      set JAVA_HOME="%~2"
+      set JDK_HOME="%~2"
+      shift
+    ) else (
+      echo Directory "%~2" for JAVA_HOME is not valid
+      goto error
+    )
+  ) else (
+    echo Second argument for --java-home missing
+    goto error
+  )
 )
 
 shift

--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -64,8 +64,8 @@ set INIT_SBT_VERSION=_TO_BE_REPLACED
 :args_loop
 if "%~1" == "" goto args_end
 
-if "%~1" == "-jvm-debug" set set JVM_DEBUG=true
-if "%~1" == "--jvm-debug" set set JVM_DEBUG=true
+if "%~1" == "-jvm-debug" set JVM_DEBUG=true
+if "%~1" == "--jvm-debug" set JVM_DEBUG=true
 
 if "%JVM_DEBUG%" == "true" (
   set /a JVM_DEBUG_PORT=5005 2>nul >nul


### PR DESCRIPTION
Fixes: sbt/sbt#4768

In contrast to the unix version of the sbt launcher, the windows version lacks the functionality of specifying JAVA_HOME via launch parameters. This commit adds the missing --java-home parameter to sbt.bat.
Additionally, I fixed JVM_DEBUG along the way.