### PR TITLE
Add -V|-version to print sbtVersion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Usage: sbt [options]
 
   -h | -help         print this message
   -v | -verbose      this runner is chattier
+  -V | -version      print the version of mothership sbt
   -d | -debug        set sbt log level to debug
   -no-colors         disable ANSI color codes
   -sbt-create        start sbt even if current directory contains no sbt project

--- a/integration-test/src/test/scala/RunnerTest.scala
+++ b/integration-test/src/test/scala/RunnerTest.scala
@@ -79,4 +79,14 @@ object SbtRunnerTest extends SimpleTestSuite with PowerAssertions {
     ()
   }
 
+  test("sbt -V|-version should print sbtVersion") {
+    val out = sbtProcessWithOpts("-version", "", "").!!.trim
+    val expectedVersion = "^sbt version in this project: \\d\\.\\d+\\.\\d+\\S*$"
+    assert(out.matches(expectedVersion))
+
+    val out2 = sbtProcessWithOpts("-V", "", "").!!.trim
+    assert(out2.matches(expectedVersion))
+    ()
+  }
+
 }

--- a/src/linux/usr/share/man/man1/sbt.1
+++ b/src/linux/usr/share/man/man1/sbt.1
@@ -20,6 +20,8 @@ The current directory is assumed to be the project.
 Show help options.
 .IP "-v, -verbose"
 turn up the noise
+.IP "-V, -version"
+print the version of mothership sbt
 .IP "-d, -debug"
 set sbt log level to debug
 .IP -no-colors

--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -6,6 +6,7 @@ declare -a java_args
 declare -a scalac_args
 declare -a sbt_commands
 declare -a sbt_options
+declare -a print_sbt_version
 declare java_cmd=java
 declare java_version
 declare init_sbt_version=_to_be_replaced
@@ -375,14 +376,19 @@ run() {
     addJava "-Dsbt.cygwin=true"
   fi
 
-  # run sbt
-  execRunner "$java_cmd" \
-    $(get_gc_opts) \
-    ${java_args[@]} \
-    ${sbt_options[@]} \
-    -jar "$sbt_jar" \
-    "${sbt_commands[@]}" \
-    "${residual_args[@]}"
+  if [[ $print_sbt_version ]]; then
+    # print sbtVersion
+    execRunner "$java_cmd" -jar "$sbt_jar" "sbtVersion" | tail -1
+  else
+    # run sbt
+    execRunner "$java_cmd" \
+      $(get_gc_opts) \
+      ${java_args[@]} \
+      ${sbt_options[@]} \
+      -jar "$sbt_jar" \
+      "${sbt_commands[@]}" \
+      "${residual_args[@]}"
+  fi
 
   exit_code=$?
 
@@ -442,7 +448,7 @@ Usage: `basename "$0"` [options]
                       are prepended to the runner args
   /etc/sbt/sbtopts    if this file exists, it is prepended to the runner args
   -Dkey=val           pass -Dkey=val directly to the java runtime
-  -J-X                pass option -X directly to the java runtime 
+  -J-X                pass option -X directly to the java runtime
                       (-J is stripped)
   -S-X                add -X to sbt's scalacOptions (-S is stripped)
 
@@ -465,7 +471,7 @@ process_my_args () {
   done
 
   # Now, ensure sbt version is used.
-  [[ "${sbt_version}XXX" != "XXX" ]] && addJava "-Dsbt.version=$sbt_version" 
+  [[ "${sbt_version}XXX" != "XXX" ]] && addJava "-Dsbt.version=$sbt_version"
 
   # Confirm a user's intent if the current directory does not look like an sbt
   # top-level directory and neither the -sbt-create option nor the "new"
@@ -513,7 +519,7 @@ process_args () {
     case "$1" in
        -h|-help) usage; exit 1 ;;
     -v|-verbose) verbose=1 && shift ;;
-    -V|-version) addSbt "sbtVersion" && shift ;;
+    -V|-version) print_sbt_version=1 && shift ;;
       -d|-debug) debug=1 && addSbt "-debug" && shift ;;
 
            -ivy) require_arg path "$1" "$2" && addJava "-Dsbt.ivy.home=$2" && shift 2 ;;

--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -405,6 +405,7 @@ Usage: `basename "$0"` [options]
 
   -h | --help         print this message
   -v | --verbose      this runner is chattier
+  -V | --version      print the version of mothership sbt
   -d | --debug        set sbt log level to debug
   --no-colors         disable ANSI color codes
   --color=auto|always|true|false|never
@@ -512,6 +513,7 @@ process_args () {
     case "$1" in
        -h|-help) usage; exit 1 ;;
     -v|-verbose) verbose=1 && shift ;;
+    -V|-version) addSbt "sbtVersion" && shift ;;
       -d|-debug) debug=1 && addSbt "-debug" && shift ;;
 
            -ivy) require_arg path "$1" "$2" && addJava "-Dsbt.ivy.home=$2" && shift 2 ;;

--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -378,7 +378,7 @@ run() {
 
   if [[ $print_sbt_version ]]; then
     # print sbtVersion
-    execRunner "$java_cmd" -jar "$sbt_jar" "sbtVersion" | tail -1
+    execRunner "$java_cmd" -jar "$sbt_jar" "sbtVersion" | tail -1 | sed -e 's/\[info\]/sbt version in this project:/g'
   else
     # run sbt
     execRunner "$java_cmd" \


### PR DESCRIPTION
Closes https://github.com/sbt/sbt/issues/4833
Add `-V|-version` as a shortcut print `sbtVersion`.
It will print the single line `[info] 1.2.8` or similar.

Not tested yet due to #275.

