### PR TITLE
Capture double dashes in process args

### DIFF
--- a/integration-test/src/test/scala/RunnerTest.scala
+++ b/integration-test/src/test/scala/RunnerTest.scala
@@ -9,10 +9,7 @@ object SbtRunnerTest extends SimpleTestSuite with PowerAssertions {
   lazy val sbtScript =
     if (isWindows) new File("target/universal/stage/bin/sbt.bat")
     else new File("target/universal/stage/bin/sbt")
-  def sbtProcess(arg: String) =
-    sbt.internal.Process(sbtScript.getAbsolutePath + " " + arg, new File("citest"),
-      "JAVA_OPTS" -> "",
-      "SBT_OPTS" -> "")
+  def sbtProcess(arg: String) = sbtProcessWithOpts(arg, "", "")
   def sbtProcessWithOpts(arg: String, javaOpts: String, sbtOpts: String) =
     sbt.internal.Process(sbtScript.getAbsolutePath + " " + arg, new File("citest"),
       "JAVA_OPTS" -> javaOpts,
@@ -52,6 +49,12 @@ object SbtRunnerTest extends SimpleTestSuite with PowerAssertions {
   test("sbt --timings") {
     val out = sbtProcess("compile --timings -v").!!.linesIterator.toList
     assert(out.contains[String]("-Dsbt.task.timings=true"))
+    ()
+  }
+
+  test("sbt --sbt-version") {
+    val out = sbtProcess("--sbt-version 1.3.0 compile -v").!!.linesIterator.toList
+    assert(out.contains[String]("-Dsbt.version=1.3.0"))
     ()
   }
 

--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -516,28 +516,28 @@ map_args () {
 process_args () {
   while [[ $# -gt 0 ]]; do
     case "$1" in
-       -h|-help) usage; exit 1 ;;
-    -v|-verbose) sbt_verbose=1 && shift ;;
-    -V|-version) print_sbt_version=1 && shift ;;
-      -d|-debug) sbt_debug=1 && addSbt "-debug" && shift ;;
+            -h|-help|--help) usage; exit 1 ;;
+      -v|-verbose|--verbose) sbt_verbose=1 && shift ;;
+      -V|-version|--version) print_sbt_version=1 && shift ;;
+          -d|-debug|--debug) sbt_debug=1 && addSbt "-debug" && shift ;;
 
-           -ivy) require_arg path "$1" "$2" && addJava "-Dsbt.ivy.home=$2" && shift 2 ;;
-           -mem) require_arg integer "$1" "$2" && addMemory "$2" && shift 2 ;;
-     -jvm-debug) require_arg port "$1" "$2" && addDebugger $2 && shift 2 ;;
-         -batch) exec </dev/null && shift ;;
+                 -ivy|--ivy) require_arg path "$1" "$2" && addJava "-Dsbt.ivy.home=$2" && shift 2 ;;
+                 -mem|--mem) require_arg integer "$1" "$2" && addMemory "$2" && shift 2 ;;
+     -jvm-debug|--jvm-debug) require_arg port "$1" "$2" && addDebugger $2 && shift 2 ;;
+             -batch|--batch) exec </dev/null && shift ;;
 
-       -sbt-jar) require_arg path "$1" "$2" && sbt_jar="$2" && shift 2 ;;
-   -sbt-version) require_arg version "$1" "$2" && sbt_version="$2" && shift 2 ;;
-     -java-home) require_arg path "$1" "$2" &&
-                 java_cmd="$2/bin/java" &&
-                 export JAVA_HOME="$2" &&
-                 export JDK_HOME="$2" &&
-                 export PATH="$2/bin:$PATH" &&
-                 shift 2 ;;
+         -sbt-jar|--sbt-jar) require_arg path "$1" "$2" && sbt_jar="$2" && shift 2 ;;
+ -sbt-version|--sbt-version) require_arg version "$1" "$2" && sbt_version="$2" && shift 2 ;;
+     -java-home|--java-home) require_arg path "$1" "$2" &&
+                             java_cmd="$2/bin/java" &&
+                             export JAVA_HOME="$2" &&
+                             export JDK_HOME="$2" &&
+                             export PATH="$2/bin:$PATH" &&
+                             shift 2 ;;
 
-      "-D*"|-D*) addJava "$1" && shift ;;
-            -J*) addJava "${1:2}" && shift ;;
-              *) addResidual "$1" && shift ;;
+                  "-D*"|-D*) addJava "$1" && shift ;;
+                        -J*) addJava "${1:2}" && shift ;;
+                          *) addResidual "$1" && shift ;;
     esac
   done
 


### PR DESCRIPTION
Changes were made in https://github.com/sbt/sbt-launcher-package/pull/259 to add double dashes for process_args, but in a different file that got deleted over the course of time. This change re-instates double dashes