### PR TITLE
Drop -XX:+UseParallelGC

### DIFF
--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -185,21 +185,6 @@ addDefaultMemory() {
   fi
 }
 
-get_gc_opts () {
-  local older_than_9=$(( $java_version < 9 ))
-
-  if [[ "$older_than_9" == "1" ]]; then
-    # don't need to worry about gc
-    echo ""
-  elif [[ "${JAVA_OPTS}" =~ Use.*GC ]] || [[ "${JAVA_TOOL_OPTIONS}" =~ Use.*GC ]] || [[ "${SBT_OPTS}" =~ Use.*GC ]] ; then
-    # GC arg has been passed in - don't change
-    echo ""
-  else
-    # Java 9+ so revert to old
-    echo "-XX:+UseParallelGC"
-  fi
-}
-
 require_arg () {
   local type="$1"
   local opt="$2"
@@ -381,7 +366,6 @@ run() {
   else
     # run sbt
     execRunner "$java_cmd" \
-      $(get_gc_opts) \
       "${java_args[@]}" \
       "${sbt_options[@]}" \
       -jar "$sbt_jar" \

--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -198,13 +198,6 @@ if /I %JAVA_VERSION% GEQ 9 (
     "%_JAVACMD%" %_JAVA_OPTS% %SBT_OPTS% -jar "!rtexport!" "!java9_rt!"
   )
   set _JAVA_OPTS=!_JAVA_OPTS! -Dscala.ext.dirs="!java9_ext!"
-
-  rem check to see if a GC has been set in the opts
-  echo !_JAVA_OPTS! | findstr /r "Use.*GC" >nul
-  if ERRORLEVEL 1 (
-    rem don't have a GC set - revert to old GC
-    set _JAVA_OPTS=!_JAVA_OPTS! -XX:+UseParallelGC
-  )
 )
 exit /B 0
 


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/5045

Currently we set `-XX:+UseParallelGC` for JDK greater than 9. This isn't a great default because while the peak throughput is somewhat better than the default g1 collector, the worst case performance is really bad with UseParallelGC, especially when the heap size is large.

Given the sudden diversification of JDK implementations, we should stay clear from `-XX` flags, and let the build users add them if they must.