### PR TITLE
Update sbt.bat to match bash sbt command line usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
         - unzip /tmp/sbt.zip -d $HOME/sbt
         - export PATH="$HOME/sbt/sbt/bin:$PATH"
       script:
-        - sbt -Dsbt.build.version=$SBT_VER universal:packageBin
+        - sbt -Dsbt.build.version=$SBT_VER universal:packageBin universal:stage integrationTest/test
         - cd citest
         - "./test.bat"
         - "test3/test3.bat"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ scala: 2.10.7
 env:
   global:
     - SBT_VER=1.3.0
-    - TRAVIS_JDK=adopt@1.8.212-04
+    - TRAVIS_JDK=adopt@1.8.0-222
     - JABBA_HOME=$HOME/.jabba
     - TRAVIS_JDK11=openjdk@1.11.0
     ## ignore Travis CI's default /etc/sbt/sbtopts

--- a/build.sbt
+++ b/build.sbt
@@ -181,7 +181,7 @@ val root = (project in file(".")).
           val x = IO.read(k)
           IO.write(t / "sbt", x.replaceAllLiterally(
             "declare init_sbt_version=_to_be_replaced",
-            s"""declare init_sbt_version=$sbtVersionToRelease"""))
+            s"declare init_sbt_version=$sbtVersionToRelease"))
 
           if (FileSystems.getDefault.supportedFileAttributeViews.contains("posix")) {
             val perms = Files.getPosixFilePermissions(k.toPath)
@@ -192,8 +192,8 @@ val root = (project in file(".")).
         case (k, BinBat) =>
           val x = IO.read(k)
           IO.write(t / "sbt.bat", x.replaceAllLiterally(
-            "set INIT_SBT_VERSION=_TO_BE_REPLACED",
-            s"""set INIT_SBT_VERSION=$sbtVersionToRelease"""))
+            "set init_sbt_version=_to_be_replaced",
+            s"set init_sbt_version=$sbtVersionToRelease"))
           (t / "sbt.bat", BinBat)
         case (k, v) => (k, v)
       }
@@ -249,7 +249,7 @@ lazy val integrationTest = (project in file("integration-test"))
     libraryDependencies ++= Seq(
       "io.monix" %% "minitest" % "2.3.2" % Test,
       "com.eed3si9n.expecty" %% "expecty" % "0.11.0" % Test,
-      "org.scala-sbt" %% "io" % "1.2.2" % Test
+      "org.scala-sbt" %% "io" % "1.3.1" % Test
     ),
     testFrameworks += new TestFramework("minitest.runner.Framework")
   )

--- a/citest/test.bat
+++ b/citest/test.bat
@@ -19,4 +19,13 @@ SET SBT_OPTS=-Xmx4g -Dfile.encoding=UTF8
 
 "freshly-baked\sbt\bin\sbt" -Dsbt.no.format=true check
 
+"freshly-baked\sbt\bin\sbt" -Dsbt.no.format=true --numeric-version > numericVersion.txt
+"freshly-baked\sbt\bin\sbt" -Dsbt.no.format=true checkNumericVersion
+
+"freshly-baked\sbt\bin\sbt" -Dsbt.no.format=true --script-version > scriptVersion.txt
+"freshly-baked\sbt\bin\sbt" -Dsbt.no.format=true checkScriptVersion
+
+"freshly-baked\sbt\bin\sbt" -Dsbt.no.format=true --version > version.txt
+"freshly-baked\sbt\bin\sbt" -Dsbt.no.format=true checkVersion
+
 ENDLOCAL

--- a/citest/test3/build.sbt
+++ b/citest/test3/build.sbt
@@ -1,4 +1,10 @@
 lazy val check = taskKey[Unit]("")
+lazy val checkNumericVersion = taskKey[Unit]("")
+lazy val checkScriptVersion = taskKey[Unit]("")
+lazy val checkVersion = taskKey[Unit]("")
+
+// 1.3.0, 1.3.0-M4
+lazy val versionRegEx = "\\d(\\.\\d+){2}(-\\w+)?"
 
 lazy val root = (project in file("."))
   .settings(
@@ -20,5 +26,27 @@ lazy val root = (project in file("."))
 
       assert(ys.size == 1, s"ys has more than one item: $ys")
       assert(ys(0) startsWith "Java HotSpot(TM) 64-Bit Server VM warning")
+    },
+    checkNumericVersion = {
+      val xs = IO.readLines(file("numericVersion.txt")).toVector
+      val expectedVersion = "^"+versionRegEx+"$"
+
+      assert(xs(0).matches(expectedVersion))
+    },
+    checkScriptVersion = {
+      val xs = IO.readLines(file("scriptVersion.txt")).toVector
+      val expectedVersion = "^"+versionRegEx+"$"
+
+      assert(xs(0).matches(expectedVersion))
+    },
+    checkVersion = {
+      val out = IO.readLines(file("version.txt")).toVector.mkString("\n")
+
+      val expectedVersion =
+        s"""|(?m)^sbt version in this project: $versionRegEx
+           |sbt script version: $versionRegEx$$
+           |""".stripMargin.trim.replace("\n", "\\n")
+
+      assert(out.matches(expectedVersion))
     }
   )

--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -176,11 +176,29 @@ addMemory () {
 addDefaultMemory() {
   # if we detect any of these settings in ${JAVA_OPTS} or ${JAVA_TOOL_OPTIONS} we need to NOT output our settings.
   # The reason is the Xms/Xmx, if they don't line up, cause errors.
-  if [[ "${java_args[@]}" == *-Xmx* ]] || [[ "${java_args[@]}" == *-Xms* ]]; then
+  if [[ "${java_args[@]}" == *-Xmx* ]] || \
+     [[ "${java_args[@]}" == *-Xms* ]] || \
+     [[ "${java_args[@]}" == *-XX:+UseCGroupMemoryLimitForHeap* ]] || \
+     [[ "${java_args[@]}" == *-XX:MaxRAM* ]] || \
+     [[ "${java_args[@]}" == *-XX:InitialRAMPercentage* ]] || \
+     [[ "${java_args[@]}" == *-XX:MaxRAMPercentage* ]] || \
+     [[ "${java_args[@]}" == *-XX:MinRAMPercentage* ]]; then
     :
-  elif [[ "${JAVA_TOOL_OPTIONS}" == *-Xmx* ]] || [[ "${JAVA_TOOL_OPTIONS}" == *-Xms* ]]; then
+  elif [[ "${JAVA_TOOL_OPTIONS}" == *-Xmx* ]] || \
+       [[ "${JAVA_TOOL_OPTIONS}" == *-Xms* ]] || \
+       [[ "${JAVA_TOOL_OPTIONS}" == *-XX:+UseCGroupMemoryLimitForHeap* ]] || \
+       [[ "${JAVA_TOOL_OPTIONS}" == *-XX:MaxRAM* ]] || \
+       [[ "${JAVA_TOOL_OPTIONS}" == *-XX:InitialRAMPercentage* ]] || \
+       [[ "${JAVA_TOOL_OPTIONS}" == *-XX:MaxRAMPercentage* ]] || \
+       [[ "${JAVA_TOOL_OPTIONS}" == *-XX:MinRAMPercentage* ]] ; then
     :
-  elif [[ "${sbt_options[@]}" == *-Xmx* ]] || [[ "${sbt_options[@]}" == *-Xms* ]]; then
+  elif [[ "${sbt_options[@]}" == *-Xmx* ]] || \
+       [[ "${sbt_options[@]}" == *-Xms* ]] || \
+       [[ "${sbt_options[@]}" == *-XX:+UseCGroupMemoryLimitForHeap* ]] || \
+       [[ "${sbt_options[@]}" == *-XX:MaxRAM* ]] || \
+       [[ "${sbt_options[@]}" == *-XX:InitialRAMPercentage* ]] || \
+       [[ "${sbt_options[@]}" == *-XX:MaxRAMPercentage* ]] || \
+       [[ "${sbt_options[@]}" == *-XX:MinRAMPercentage* ]] ; then
     :
   else
     addMemory $sbt_default_mem

--- a/src/universal/conf/sbtconfig.txt
+++ b/src/universal/conf/sbtconfig.txt
@@ -2,10 +2,12 @@
 
 # Set the java args
 
--Xms1024m
--Xmx1024m
--Xss4M
--XX:ReservedCodeCacheSize=128m
+#-mem 1024 was added in sbt.bat as default
+
+#-Xms1024m
+#-Xmx1024m
+#-Xss4M
+#-XX:ReservedCodeCacheSize=128m
 
 # Set the extra sbt options
 


### PR DESCRIPTION
This started as an initial scrub of the `sbt.bat` but is shaping up to be a full port of the bash `sbt` to windows bat `sbt.bat`

* Implement (nearly all?) of the bash `sbt` `--help` arguments
* Windows now uses the same `integrationTest/test`


TODO:

- [ ] parse input `SBT_OPTS` (environment `SBT_OPTS`, `.sbtopts`, and `sbtconfig.txt`?) for arguments (e.g. `--no-color` and convert to appropriate `-Dsbt.log.noformat=true` options)
- [ ] Process memory arguments from SBT_OPTS (e.g. `-Xms2048M -Xmx2048M -Xss6M`)
