### PR TITLE
Update --version response to only return the version

### DIFF
--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -362,7 +362,7 @@ run() {
 
   if [[ $print_sbt_version ]]; then
     # print sbtVersion
-    execRunner "$java_cmd" -jar "$sbt_jar" "sbtVersion" | tail -1 | sed -e 's/\[info\]/sbt version in this project:/g'
+    execRunner "$java_cmd" -jar "$sbt_jar" "sbtVersion" | tail -1 | sed -e 's/\[info\]//g'
   else
     # run sbt
     execRunner "$java_cmd" \


### PR DESCRIPTION
This is for discussion.  I'm not sure if it was previously discussed, but simplifying the output to be the version number helps assist in CI/DI pipelines looking to parse out the current `sbt` version.

I understand that the `project version` and `tool version` are different, so perhaps that is the motivation for the current response.

An alternate approach could be to print out both the tool and project version (e.g.):

```bash
sbt: 1.3.2
sbt version in this project: 1.2.8
```

Ideally the `--version` would return the tool version (perhaps the `initial_sbt_version`)

But that would be a backward-breaking change.