### PR TITLE
Fix equal sign handling for -D

### DIFF
--- a/citest/test.bat
+++ b/citest/test.bat
@@ -13,10 +13,10 @@ SET JAVA_HOME=C:\jdk11
 SET PATH=C:\jdk11\bin;%PATH%
 SET SBT_OPTS=-Xmx4g -Dfile.encoding=UTF8
 
-"freshly-baked\sbt\bin\sbt" "-Dsbt.no.format=true" about
+"freshly-baked\sbt\bin\sbt" -Dsbt.no.format=true about
 
-"freshly-baked\sbt\bin\sbt" "-Dsbt.no.format=true" about 1> output.txt 2> err.txt
+"freshly-baked\sbt\bin\sbt" -Dsbt.no.format=true about 1> output.txt 2> err.txt
 
-"freshly-baked\sbt\bin\sbt" "-Dsbt.no.format=true" check
+"freshly-baked\sbt\bin\sbt" -Dsbt.no.format=true check
 
 ENDLOCAL

--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -64,6 +64,7 @@ set INIT_SBT_VERSION=_TO_BE_REPLACED
 :args_loop
 if "%~1" == "" goto args_end
 
+set g=%1
 if "%~1" == "-jvm-debug" set JVM_DEBUG=true
 if "%~1" == "--jvm-debug" set JVM_DEBUG=true
 
@@ -80,6 +81,19 @@ if "%JVM_DEBUG%" == "true" (
 ) else if /I "%~1" == "new" (
   set sbt_new=true
   set SBT_ARGS=!SBT_ARGS! %1
+) else if /I "%g:~0,2%" == "-D" (
+  rem special handling for -D since '=' gets parsed away
+  if x%g:^==% == x%g% (
+    if not "%~2" == "" (
+      set SBT_ARGS=!SBT_ARGS! "%~1=%~2"
+      shift
+    ) else (
+      echo "%~1" is missing a value
+      goto error
+    )
+  ) else (
+    set SBT_ARGS=!SBT_ARGS! %1
+  )
 ) else (
   set SBT_ARGS=!SBT_ARGS! %1
 )


### PR DESCRIPTION
Fixes sbt/sbt#2695
By the time the arguments are passed to a batch script,
it seems like  is parsed away.
for /F did not work since it would not handle double quoted
paths that include whitespaces.
This adds special handling for -D parameters only.

/cc @er1c 
