### PR TITLE
Update javacOptions to target 1.8 & Add IntelliJ integrationTest/test run configuration

### DIFF
--- a/.idea/runConfigurations/Run_integrationTest_test.xml
+++ b/.idea/runConfigurations/Run_integrationTest_test.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run integrationTest/test" type="SbtRunConfiguration" factoryName="sbt Task" show_console_on_std_err="false" show_console_on_std_out="false">
+    <option name="allowRunningInParallel" value="false" />
+    <option name="tasks" value="-Dsbt.build.version=1.3.0 universal:packageBin universal:stage integrationTest/test" />
+    <option name="useSbtShell" value="true" />
+    <option name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
+    <option name="workingDir" value="$PROJECT_DIR$" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/build.sbt
+++ b/build.sbt
@@ -163,7 +163,7 @@ val root = (project in file(".")).
     packageDescription in Windows := "The interactive build tool.",
     wixProductId := "ce07be71-510d-414a-92d4-dff47631848a",
     wixProductUpgradeId := Hash.toHex(Hash((version in Windows).value)).take(32),
-    javacOptions := Seq("-source", "1.5", "-target", "1.5"),
+    javacOptions := Seq("-source", "1.8", "-target", "1.8"),
 
     // Universal ZIP download install.
     packageName in Universal := packageName.value, // needs to be set explicitly due to a bug in native-packager


### PR DESCRIPTION
Opening for discussion, I always have to dig into the `.travis.yml` file to figure out what the test command is.

I had to update the `javacOptions` to 1.8 to get intellij "build" to work.

This is just for convenience to write tests/run from the IDE.

![image](https://user-images.githubusercontent.com/64685/67150364-6287cc00-f26b-11e9-8a9c-7f0b69f7da27.png)
