### PR TITLE
Remove unimplemented --sbt-rc and --sbt-snapshot arguments from docs and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ Usage: sbt [options]
   # sbt version (default: from project/build.properties if present, else latest release)
   -sbt-version  <version>   use the specified version of sbt
   -sbt-jar      <path>      use the specified jar as the sbt launcher
-  -sbt-rc                   use an RC version of sbt
-  -sbt-snapshot             use a snapshot version of sbt
 
   # java version (default: java from PATH, currently openjdk version "1.8.0_172")
   -java-home <path>         alternate JAVA_HOME

--- a/src/linux/usr/share/man/man1/sbt.1
+++ b/src/linux/usr/share/man/man1/sbt.1
@@ -57,10 +57,6 @@ Disable interactive mode
 Use the alternate system wide
 .IP "--sbt-jar <path>"
 use the specified jar as the sbt launcher
-.IP "--sbt-rc"
-use an RC version of sbt
-.IP --sbt-snapshot
-use a snapshot version of sbt
 .SH Java Options
 .IP "--java-home <path>"
 alternate JAVA_HOME

--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -446,8 +446,6 @@ Usage: `basename "$0"` [options]
   # sbt version (default: from project/build.properties if present, else latest release)
   --sbt-version  <version>   use the specified version of sbt
   --sbt-jar      <path>      use the specified jar as the sbt launcher
-  --sbt-rc                   use an RC version of sbt
-  --sbt-snapshot             use a snapshot version of sbt
 
   # java version (default: java from PATH, currently $(java -version 2>&1 | grep version))
   --java-home <path>         alternate JAVA_HOME

--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -766,8 +766,6 @@ echo.
 echo   # sbt version ^(default: from project/build.properties if present, else latest release^)
 echo   --sbt-version  ^<version^>   use the specified version of sbt
 rem echo   --sbt-jar      ^<path^>      use the specified jar as the sbt launcher
-rem echo   --sbt-rc                   use an RC version of sbt
-rem echo   --sbt-snapshot             use a snapshot version of sbt
 echo.
 echo   # java version ^(default: java from PATH, currently !FULL_JAVA_VERSION!^)
 echo   --java-home ^<path^>         alternate JAVA_HOME


### PR DESCRIPTION
Raised from https://github.com/sbt/sbt/issues/5178

A quick sanity check, these aren't in `sbt-extras`: https://github.com/paulp/sbt-extras

unless they were suppose to replace:

```
  -sbt-force-latest         force the use of the latest release of sbt: 1.3.3
  -sbt-dev                  use the latest pre-release version of sbt: 1.3.3
```