### PR TITLE
Use exec to launch when not in cygwin

### DIFF
--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -118,9 +118,13 @@ execRunner () {
     echo ""
   }
 
-  # This used to be exec, but we loose the ability to re-hook stty then
-  # for cygwin...  Maybe we should flag the feature here...
-  "$@"
+  if [[ "$CYGWIN_FLAG" == "true" ]]; then
+    # In cygwin we loose the ability to re-hook stty if exec is used
+    # https://github.com/sbt/sbt-launcher-package/issues/53
+    "$@"
+  else
+    exec "$@"
+  fi
 }
 
 addJava () {


### PR DESCRIPTION
This allows, for example, capturing the correct PID when launching sbt from within a bash script. The original change from 1a0715056050469b5b713d11d635f782b829f7bf was to address an issue specific to cygwin (#53).