### PR TITLE
Fix parsing of Windows command line arguments with whitespaces/quotes

### DIFF
--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -118,7 +118,7 @@ if not defined _SBT_OPTS if defined default_sbt_opts set _SBT_OPTS=!default_sbt_
 :args_loop
 shift
 
-if [%0] EQU [] goto args_end
+if "%~0" == "" goto args_end
 set g=%~0
 
 if "%~0" == "-h" goto usage
@@ -368,7 +368,7 @@ if "%~0" == "--jvm-debug" set _jvm_debug_arg=true
 
 if defined _jvm_debug_arg (
   set _jvm_debug_arg=
-  if [%1] NEQ [] (
+  if not "%~1" == "" (
     set /a JVM_DEBUG_PORT=%~1 2>nul >nul
     if !JVM_DEBUG_PORT! EQU 0 (
       rem next argument wasn't a port, set a default and process next arg
@@ -383,7 +383,7 @@ if "%~0" == "--java-home" set _java_home_arg=true
 
 if defined _java_home_arg (
   set _java_home_arg=
-  if [%1] NEQ [] (
+  if not "%~1" == "" (
     if exist "%~1\bin\java.exe" (
       set "_JAVACMD=%~1\bin\java.exe"
       set "JAVA_HOME=%~1"
@@ -595,7 +595,7 @@ if defined sbt_args_verbose (
   echo -cp
   echo "!sbt_jar!"
   echo xsbt.boot.Boot
-  if not [%~1] == [] ( call :echolist %* )
+  if not "%~1" == "" ( call :echolist %* )
   echo.
 )
 
@@ -609,7 +609,7 @@ rem fixes dealing with quotes after = args: -Dscala.ext.dirs="C:\Users\First Las
 rem call method is in first call of %0
 shift
 
-if [%0] EQU [] goto echolist_end
+if "%~0" == "" goto echolist_end
 set "p=%0"
 
 if "%p:~0,2%" == "-D" (


### PR DESCRIPTION
This consolidates the style and allows to pass arguments with spaces to SBT

Example of a culpruit:
if not [%~1] == [] 

When trying to invoke `sbt.bat "show sources"` this will expand to:
if not [show sources] == []
and promptly explode. 

One needs to re-quote immediately when using %~X to remove quotes since otherwise batch parser will croak as it only expects a single argument there.