### PR TITLE
don't use execRunner to copy rt.jar

### DIFF
--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -105,6 +105,7 @@ rt_export_file () {
   echo "${sbt_bin_dir}/java9-rt-export.jar"
 }
 
+# execRunner should be called only once to give up control to java
 execRunner () {
   # print the arguments one to a line, quoting any containing spaces
   [[ $sbt_verbose || $sbt_debug ]] && echo "# Executing command line:" && {
@@ -336,9 +337,9 @@ copyRt() {
     java9_rt=$(echo "$java9_ext/rt.jar")
     vlog "[copyRt] java9_rt = '$java9_rt'"
     if [[ ! -f "$java9_rt" ]]; then
-      echo Copying runtime jar.
+      echo copying runtime jar...
       mkdir -p "$java9_ext"
-      execRunner "$java_cmd" \
+      "$java_cmd" \
         "${sbt_options[@]}" \
         "${java_args[@]}" \
         -jar "$rtexport" \


### PR DESCRIPTION
Ref https://github.com/sbt/sbt-launcher-package/pull/308
Fixes https://github.com/sbt/sbt/issues/5270

The first time `sbt` runs on JDK 11, it copies the `rt.jar` by calling `execRunner java`.. it seems like the control never comes back from it and `sbt` just ends there. This fixes the problem by not calling `execRunner` for that operation.