### PR TITLE
Fix rsync check path

### DIFF
--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -292,12 +292,12 @@ syncPreloaded() {
     # FIXME: better $init_sbt_version detection
     init_sbt_version="$(ls -1 "$source_preloaded/org/scala-sbt/sbt/")"
   fi
-  [[ -f "$target_preloaded/org.scala-sbt/sbt/$init_sbt_version/jars/sbt.jar" ]] || {
+  [[ -f "$target_preloaded/org/scala-sbt/sbt/$init_sbt_version/" ]] || {
     # lib/local-preloaded exists (This is optional)
     [[ -d "$source_preloaded" ]] && {
       command -v rsync >/dev/null 2>&1 && {
         mkdir -p "$target_preloaded"
-        rsync -a --ignore-existing "$source_preloaded" "$target_preloaded"
+        rsync -a --ignore-existing "$source_preloaded" "$target_preloaded" || true
       }
     }
   }


### PR DESCRIPTION
Starting sbt 1.3.x we use Coursier to build the preloaded local repo using Maven layout.