### PR TITLE
rsync flags

### DIFF
--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -297,7 +297,7 @@ syncPreloaded() {
     [[ -d "$source_preloaded" ]] && {
       command -v rsync >/dev/null 2>&1 && {
         mkdir -p "$target_preloaded"
-        rsync -a --ignore-existing "$source_preloaded" "$target_preloaded" || true
+        rsync --recursive --links --perms --times --ignore-existing "$source_preloaded" "$target_preloaded" || true
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/5035

Currently `sbt` calls `rsync -a`, which expands to `-rlptgoD`, including `--group` and `--owner` flag that preserves the group and owner of the files. This drops the requirement since we just need to copy files around with the right timestamp.