### PR TITLE
Fixed expansion of args with whitespace in JDK 9+.

### DIFF
--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -332,7 +332,7 @@ copyRt() {
   if [[ "$at_least_9" == "1" ]]; then
     rtexport=$(rt_export_file)
     # The grep for java9-rt-ext- matches the filename prefix printed in Export.java
-    java9_ext=$("$java_cmd" ${sbt_options[@]} ${java_args[@]} \
+    java9_ext=$("$java_cmd" "${sbt_options[@]}" "${java_args[@]}" \
       -jar "$rtexport" --rt-ext-dir | grep java9-rt-ext-)
     java9_rt=$(echo "$java9_ext/rt.jar")
     vlog "[copyRt] java9_rt = '$java9_rt'"


### PR DESCRIPTION
Solves the issue where providing sbt_options and java_args containing whitespaces on Java 9 and higher would fail. Expansion of sbt_options and java_args containing whitespaces would not expand correctly in copyRt(), but instead would create an invalid java command due to missing quotes.