### PR TITLE
Support the -debug flag in SBT_OPTS

### DIFF
--- a/integration-test/src/test/scala/RunnerTest.scala
+++ b/integration-test/src/test/scala/RunnerTest.scala
@@ -138,10 +138,13 @@ object SbtRunnerTest extends SimpleTestSuite with PowerAssertions {
   }
 
   test("sbt with -debug in SBT_OPTS appears in sbt commands") {
+    if (isWindows) cancel("Test not supported on windows")
+
     val out: List[String] = sbtProcessWithOpts("compile", "-v")("", "-debug").!!.linesIterator.toList
-    // Debug argument must appear in the 'commands' section after sbt-launch.jar to work
+    // Debug argument must appear in the 'commands' section (after the sbt-launch.jar argument) to work
+    val sbtLaunchMatcher = """^.+sbt-launch.jar["]{0,1}$""".r
     val locationOfSbtLaunchJarArg = out.zipWithIndex.collectFirst {
-      case (arg, index) if arg.endsWith("sbt-launch.jar") => index
+      case (arg, index) if sbtLaunchMatcher.findFirstIn(arg).nonEmpty => index
     }
 
     assert(locationOfSbtLaunchJarArg.nonEmpty)

--- a/integration-test/src/test/scala/RunnerTest.scala
+++ b/integration-test/src/test/scala/RunnerTest.scala
@@ -137,6 +137,20 @@ object SbtRunnerTest extends SimpleTestSuite with PowerAssertions {
     ()
   }
 
+  test("sbt with -debug in SBT_OPTS appears in sbt commands") {
+    val out: List[String] = sbtProcessWithOpts("compile", "-v")("", "-debug").!!.linesIterator.toList
+    // Debug argument must appear in the 'commands' section after sbt-launch.jar to work
+    val locationOfSbtLaunchJarArg = out.zipWithIndex.collectFirst {
+      case (arg, index) if arg.endsWith("sbt-launch.jar") => index
+    }
+
+    assert(locationOfSbtLaunchJarArg.nonEmpty)
+
+    val argsAfterSbtLaunch = out.drop(locationOfSbtLaunchJarArg.get)
+    assert(argsAfterSbtLaunch.contains("-debug"))
+    ()
+  }
+
   test("sbt -V|-version|--version should print sbtVersion") {
     val out = sbtProcess("-version").!!.trim
     val expectedVersion =

--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -353,11 +353,11 @@ run() {
   java_args=($JAVA_OPTS)
   sbt_options0=(${SBT_OPTS:-$default_sbt_opts})
 
-  # Split SBT_OPTs into options/commands
+  # Split SBT_OPTS into options/commands
   miniscript=$(map_args "${sbt_options0[@]}") && eval "${miniscript/options/sbt_options}" && \
   eval "${miniscript/commands/sbt_additional_commands}"
 
-  # Combine command line options/commands and commands from SBT_OPTs
+  # Combine command line options/commands and commands from SBT_OPTS
   miniscript=$(map_args "$@") && eval "${miniscript/options/cli_options}" && eval "${miniscript/commands/cli_commands}"
   args1=( "${cli_options[@]}" "${cli_commands[@]}" "${sbt_additional_commands[@]}" )
 

--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -133,7 +133,7 @@ addJava () {
   java_args=( "${java_args[@]}" "$1" )
 }
 addSbt () {
-  dlog "[addSbt] arg = '$1'"
+  echoerr "[addSbt] arg = '$1'"
   sbt_commands=( "${sbt_commands[@]}" "$1" )
 }
 addResidual () {
@@ -350,14 +350,21 @@ copyRt() {
 }
 
 run() {
-  local retarr=()
   java_args=($JAVA_OPTS)
   sbt_options0=(${SBT_OPTS:-$default_sbt_opts})
-  miniscript=$(map_args "${sbt_options0[@]}") && eval "${miniscript/retarr/sbt_options}"
-  miniscript=$(map_args "$@") && eval "${miniscript/retarr/args1}"
+
+  # Split SBT_OPTs into options/commands
+  miniscript=$(map_args "${sbt_options0[@]}") && eval "${miniscript/options/sbt_options}" && \
+  eval "${miniscript/commands/sbt_additional_commands}"
+
+  # Combine command line options/commands and commands from SBT_OPTs
+  miniscript=$(map_args "$@") && eval "${miniscript/options/cli_options}" && eval "${miniscript/commands/cli_commands}"
+  args1=( "${cli_options[@]}" "${cli_commands[@]}" "${sbt_additional_commands[@]}" )
+
   # process the combined args, then reset "$@" to the residuals
   process_args "${args1[@]}"
   vlog "[sbt_options] $(declare -p sbt_options)"
+
   addDefaultMemory
   set -- "${residual_args[@]}"
   argumentCount=$#
@@ -378,7 +385,7 @@ run() {
   # Java 9 support
   copyRt
 
-  #If we're in cygwin, we should use the windows config, and terminal hacks
+  # If we're in cygwin, we should use the windows config, and terminal hacks
   if [[ "$CYGWIN_FLAG" == "true" ]]; then #"
     stty -icanon min 1 -echo > /dev/null 2>&1
     addJava "-Djline.terminal=jline.UnixTerminal"
@@ -509,25 +516,28 @@ process_my_args () {
 
 ## map over argument array. this is used to process both command line arguments and SBT_OPTS
 map_args () {
-  local retarr=()
+  local options=()
+  local commands=()
   while [[ $# -gt 0 ]]; do
     case "$1" in
-     -no-colors|--no-colors) retarr=( "${retarr[@]}" "-Dsbt.log.noformat=true" ) && shift ;;
-         -timings|--timings) retarr=( "${retarr[@]}" "-Dsbt.task.timings=true" "-Dsbt.task.timings.on.shutdown=true" ) && shift ;;
-           -traces|--traces) retarr=( "${retarr[@]}" "-Dsbt.traces=true" ) && shift ;;
-             --supershell=*) retarr=( "${retarr[@]}" "-Dsbt.supershell=${1:13}" ) && shift ;;
-              -supershell=*) retarr=( "${retarr[@]}" "-Dsbt.supershell=${1:12}" ) && shift ;;
-                  --color=*) retarr=( "${retarr[@]}" "-Dsbt.color=${1:8}" ) && shift ;;
-                   -color=*) retarr=( "${retarr[@]}" "-Dsbt.color=${1:7}" ) && shift ;;
-       -no-share|--no-share) retarr=( "${retarr[@]}" "$noshare_opts" ) && shift ;;
-     -no-global|--no-global) retarr=( "${retarr[@]}" "-Dsbt.global.base=$(pwd)/project/.sbtboot" ) && shift ;;
-       -sbt-boot|--sbt-boot) require_arg path "$1" "$2" && retarr=( "${retarr[@]}" "-Dsbt.boot.directory=$2" ) && shift 2 ;;
-         -sbt-dir|--sbt-dir) require_arg path "$1" "$2" && retarr=( "${retarr[@]}" "-Dsbt.global.base=$2" ) && shift 2 ;;
-     -debug-inc|--debug-inc) retarr=( "${retarr[@]}" "-Dxsbt.inc.debug=true" ) && shift ;;
-                          *) retarr=( "${retarr[@]}" "$1" ) && shift ;;
+     -no-colors|--no-colors) options=( "${options[@]}" "-Dsbt.log.noformat=true" ) && shift ;;
+         -timings|--timings) options=( "${options[@]}" "-Dsbt.task.timings=true" "-Dsbt.task.timings.on.shutdown=true" ) && shift ;;
+           -traces|--traces) options=( "${options[@]}" "-Dsbt.traces=true" ) && shift ;;
+             --supershell=*) options=( "${options[@]}" "-Dsbt.supershell=${1:13}" ) && shift ;;
+              -supershell=*) options=( "${options[@]}" "-Dsbt.supershell=${1:12}" ) && shift ;;
+                  --color=*) options=( "${options[@]}" "-Dsbt.color=${1:8}" ) && shift ;;
+                   -color=*) options=( "${options[@]}" "-Dsbt.color=${1:7}" ) && shift ;;
+       -no-share|--no-share) options=( "${options[@]}" "$noshare_opts" ) && shift ;;
+     -no-global|--no-global) options=( "${options[@]}" "-Dsbt.global.base=$(pwd)/project/.sbtboot" ) && shift ;;
+       -sbt-boot|--sbt-boot) require_arg path "$1" "$2" && options=( "${options[@]}" "-Dsbt.boot.directory=$2" ) && shift 2 ;;
+         -sbt-dir|--sbt-dir) require_arg path "$1" "$2" && options=( "${options[@]}" "-Dsbt.global.base=$2" ) && shift 2 ;;
+             -debug|--debug) commands=( "${commands[@]}" "-debug" ) && shift ;;
+     -debug-inc|--debug-inc) options=( "${options[@]}" "-Dxsbt.inc.debug=true" ) && shift ;;
+                          *) options=( "${options[@]}" "$1" ) && shift ;;
     esac
   done
-  declare -p retarr
+  declare -p options
+  declare -p commands
 }
 
 process_args () {

--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -133,7 +133,7 @@ addJava () {
   java_args=( "${java_args[@]}" "$1" )
 }
 addSbt () {
-  echoerr "[addSbt] arg = '$1'"
+  dlog "[addSbt] arg = '$1'"
   sbt_commands=( "${sbt_commands[@]}" "$1" )
 }
 addResidual () {


### PR DESCRIPTION
Recently when installing a dependency analysis tool that wraps SBT I found myself in a situation where I couldn't control SBT's command line directly, I only had access to SBT_OPTS. To debug proxy issues along the way I needed the `-debug` flag and was surprised to find it doesn't work via SBT_OPTS. That is to say:

**Issue:** `SBT_OPTS="-debug" sbt` does not result in an sbt session with debug mode enabled in the same way that `sbt -debug` does.

**Fix in this PR:** I noticed that the `-debug` flag was being output in the same place as JVM parameters which prevents it from working, it's an argument to sbt-launch.jar not to the JVM that does not have a corresponding `-D` that I can find (i.e. I can't just do `-Dsbt.debug=true` which would be more trivial).

Hence, I've updated the code to output `-debug` after the `-jar ...sbt-launch.jar` parameter where it gets correctly picked up.

This is my first contribution to sbt and I admit only moderate bash experience but I wanted to give it a try anyway. Feedback is very welcome.

**Possible alternative approach:** I considered altering this block:
```bash
    # run sbt
    execRunner "$java_cmd" \
      "${java_args[@]}" \
      "${sbt_options[@]}" \
      -jar "$sbt_jar" \
      "${sbt_commands[@]}" \
      "${residual_args[@]}"
```

to this:

```
    # run sbt
    execRunner "$java_cmd" \
      "${java_args[@]}" \
      -jar "$sbt_jar" \
      "${sbt_options[@]}" \
      "${sbt_commands[@]}" \
      "${residual_args[@]}"
```

But I assumed there was a good reason they were separate.

**Testing notes**: Because of the slightly awkward requirement for the positioning of `-debug` the test is equally awkward.