### PR TITLE
Fix sbt --client slowness

### DIFF
--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -563,9 +563,6 @@ process_args () {
     residual_args=()
     process_my_args "${myargs[@]}"
   }
-
-  java_version="$(jdk_version)"
-  vlog "[process_args] java_version = '$java_version'"
 }
 
 loadConfigFile() {
@@ -671,7 +668,14 @@ set -- "${residual_args[@]}"
 argumentCount=$#
 
 if [[ "$(isRunNativeClient)" == "true" ]]; then
+  set -- "${residual_args[@]}"
+  argumentCount=$#
   runNativeClient
 else
+  java_version="$(jdk_version)"
+  vlog "[process_args] java_version = '$java_version'"
+  addDefaultMemory
+  set -- "${residual_args[@]}"
+  argumentCount=$#
   run
 fi


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/5980

### Before:

```bash
$ time sbt --client exit
[info] entering *experimental* thin client - BEEP WHIRR
[info] terminate the server with `shutdown`
sbt --client exit  0.16s user 0.15s system 101% cpu 0.303 total
```

sbt --client was running around 303ms (median out of 5) on my machine.

```bash
$ time sbtn exit
[info] entering *experimental* thin client - BEEP WHIRR
[info] terminate the server with `shutdown`
sbtn exit  0.05s user 0.05s system 112% cpu 0.085 total
```

On the other hand, sbtn ran in 85ms (median out of 5).

### After:

```bash
$ time ~/work/sbt-modules/sbt-launcher-package/target/universal/stage/bin/sbt --client exit
[info] entering *experimental* thin client - BEEP WHIRR
[info] terminate the server with `shutdown`
~/work/sbt-modules/sbt-launcher-package/target/universal/stage/bin/sbt  exit  0.06s user 0.08s system 111% cpu 0.127 total
```

By delaying the java version detection, I got it down to 127ms.