### PR TITLE
Set sbt script when running sbtn

### DIFF
--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -621,7 +621,7 @@ runNativeClient() {
       unset 'original_args[i]'
     fi
   done
-  execRunner "$sbtn_command" "${original_args[@]}"
+  execRunner "$sbtn_command" "--sbt-script=$0" "${original_args[@]}"
 }
 
 original_args=("$@")


### PR DESCRIPTION
There are scenarios where sbt is not on the path and may be invoked as
an absolute path from the shell. When this is the case, sbtn will fail
to start a server because of the missing sbt on the path. We can fix
this by setting the --sbt-script parameter.