### PR TITLE
Miscellaneous fixes to windows batch script

### DIFF
--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -644,6 +644,7 @@ set "_SBTNCMD=!SBT_BIN_DIR!sbtn-x86_64-pc-win32.exe"
 if defined sbt_args_verbose (
   echo # running native client
   if not "%~1" == "" ( call :echolist %* )
+  set "SBT_ARGS=-v !SBT_ARGS!"
 )
 
 rem Microsoft Visual C++ 2010 SP1 Redistributable Package (x64) is required

--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -646,6 +646,7 @@ if defined sbt_args_verbose (
   if not "%~1" == "" ( call :echolist %* )
   set "SBT_ARGS=-v !SBT_ARGS!"
 )
+set "SBT_ARGS=--sbt-script=!SBT_BIN_DIR!sbt.bat %SBT_ARGS%"
 
 rem Microsoft Visual C++ 2010 SP1 Redistributable Package (x64) is required
 rem https://www.microsoft.com/en-us/download/details.aspx?id=13523

--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -650,7 +650,7 @@ set "SBT_ARGS=--sbt-script=!SBT_BIN_DIR!sbt.bat %SBT_ARGS%"
 
 rem Microsoft Visual C++ 2010 SP1 Redistributable Package (x64) is required
 rem https://www.microsoft.com/en-us/download/details.aspx?id=13523
-"!_SBTNCMD!" %*
+"!_SBTNCMD!" %SBT_ARGS%
 
 goto :eof
 


### PR DESCRIPTION
This does the following three things:
1. Fixes `sbt --client` when no server is already running
2. Passes -v to sbtn if present so it can be applied if no server is already running
3. Sets the --sbt-script= flag so that sbt can be loaded even if sbt.bat isn't on the path