### PR TITLE
Replace spaces with %20 in path names

### DIFF
--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -621,7 +621,9 @@ runNativeClient() {
       unset 'original_args[i]'
     fi
   done
-  execRunner "$sbtn_command" "--sbt-script=$0" "${original_args[@]}"
+  sbt_script=$0
+  sbt_script=${sbt_script/ /%20}
+  execRunner "$sbtn_command" "--sbt-script=$sbt_script" "${original_args[@]}"
 }
 
 original_args=("$@")

--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -646,7 +646,9 @@ if defined sbt_args_verbose (
   if not "%~1" == "" ( call :echolist %* )
   set "SBT_ARGS=-v !SBT_ARGS!"
 )
-set "SBT_ARGS=--sbt-script=!SBT_BIN_DIR!sbt.bat %SBT_ARGS%"
+
+set "SBT_SCRIPT=!SBT_BIN_DIR: =%%20!sbt.bat"
+set "SBT_ARGS=--sbt-script=!SBT_SCRIPT! %SBT_ARGS%"
 
 rem Microsoft Visual C++ 2010 SP1 Redistributable Package (x64) is required
 rem https://www.microsoft.com/en-us/download/details.aspx?id=13523


### PR DESCRIPTION
If there are strings in the path name, the sbt-script argument will be
interpreted as multiple arguments. The thin client also needs to be
updated to handle %20 in path names.