### PR TITLE
Remove extra addDefaultMemory

### DIFF
--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -665,10 +665,6 @@ args1=( "${cli_options[@]}" "${cli_commands[@]}" "${sbt_additional_commands[@]}"
 process_args "${args1[@]}"
 vlog "[sbt_options] $(declare -p sbt_options)"
 
-addDefaultMemory
-set -- "${residual_args[@]}"
-argumentCount=$#
-
 if [[ "$(isRunNativeClient)" == "true" ]]; then
   set -- "${residual_args[@]}"
   argumentCount=$#


### PR DESCRIPTION
I think this was inadvertently left out of
75257e759b455552c3007df1ec13c351ff1db2f5. Prior to removing this,
`sbt --client exit` took about 200ms on my computer compared to about
50ms for sbtn. The sbt --client result dropped to about 80ms after this
change.