### PR TITLE
Remove leading -J from .sbtopts lines

### DIFF
--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -52,10 +52,13 @@ rem users can set SBT_OPTS via .sbtopts
 if exist .sbtopts for /F %%A in (.sbtopts) do (
   set _sbtopts_line=%%A
   if not "!_sbtopts_line:~0,1!" == "#" (
+    if "!_sbtopts_line:~0,2!" == "-J" (
+      set _sbtopts_line=!_sbtopts_line:~2,1000!
+    )
     if defined _SBT_OPTS (
-      set _SBT_OPTS=!_SBT_OPTS! %%A
+      set _SBT_OPTS=!_SBT_OPTS! !_sbtopts_line!
     ) else (
-      set _SBT_OPTS=%%A
+      set _SBT_OPTS=!_sbtopts_line!
     )
   )
 )


### PR DESCRIPTION
The windows batch script for sbt does not strip -J from lines in the
.sbtopts file, which can cause sbt to fail to run since they end up
getting passed in as unknown vm arguments.