### PR TITLE
Fix #5181 - add -Xss to java_options ignore

### DIFF
--- a/integration-test/src/test/scala/ScriptTest.scala
+++ b/integration-test/src/test/scala/ScriptTest.scala
@@ -11,6 +11,18 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
 
   private val javaBinDir = new File("integration-test", "bin").getAbsolutePath
 
+  private def makeTest(
+    name: String,
+    javaOpts: String = "",
+    sbtOpts: String = "",
+  )(args: String*)(f: List[String] => Any) = {
+    test(name) {
+      val out = sbtProcessWithOpts(args: _*)(javaOpts = javaOpts, sbtOpts = sbtOpts).!!.linesIterator.toList
+      f(out)
+      ()
+    }
+  }
+
   def sbtProcess(args: String*) = sbtProcessWithOpts(args: _*)("", "")
   def sbtProcessWithOpts(args: String*)(javaOpts: String, sbtOpts: String) = {
     val path = sys.env("PATH")
@@ -24,121 +36,112 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
     )
   }
 
-  test("sbt -no-colors") {
-    val out = sbtProcess("compile", "-no-colors").!!.linesIterator.toList
+  makeTest("sbt -no-colors")("compile", "-no-colors", "-v") { out: List[String] =>
     assert(out.contains[String]("-Dsbt.log.noformat=true"))
-    ()
   }
 
-  test("sbt --no-colors") {
-    val out = sbtProcess("compile", "--no-colors").!!.linesIterator.toList
+  makeTest("sbt --no-colors")("compile", "--no-colors", "-v") { out: List[String] =>
     assert(out.contains[String]("-Dsbt.log.noformat=true"))
-    ()
   }
 
-  test("sbt --color=false") {
-    val out = sbtProcess("compile", "--color=false", "-v").!!.linesIterator.toList
+  makeTest("sbt --color=false")("compile", "--color=false", "-v") { out: List[String] =>
     assert(out.contains[String]("-Dsbt.color=false"))
-    ()
   }
 
-  test("sbt --debug-inc") {
-    val out = sbtProcess("compile", "--debug-inc", "-v").!!.linesIterator.toList
+  makeTest("sbt --no-colors in SBT_OPTS", sbtOpts = "--no-colors")("compile", "-v") { out: List[String] =>
+    if (isWindows) cancel("Test not supported on windows")
+    assert(out.contains[String]("-Dsbt.log.noformat=true"))
+  }
+
+  makeTest("sbt --debug-inc")("compile", "--debug-inc", "-v") { out: List[String] =>
     assert(out.contains[String]("-Dxsbt.inc.debug=true"))
-    ()
   }
 
-  test("sbt --supershell=never") {
-    val out = sbtProcess("compile", "--supershell=never", "-v").!!.linesIterator.toList
+  makeTest("sbt --supershell=never")("compile", "--supershell=never", "-v") { out: List[String] =>
     assert(out.contains[String]("-Dsbt.supershell=never"))
-    ()
   }
 
-  test("sbt --timings") {
-    val out = sbtProcess("compile", "--timings", "-v").!!.linesIterator.toList
+  makeTest("sbt --timings")("compile", "--timings", "-v") { out: List[String] =>
     assert(out.contains[String]("-Dsbt.task.timings=true"))
-    ()
   }
 
-  test("sbt -D arguments") {
-    val out = sbtProcess("-Dsbt.supershell=false", "compile", "-v").!!.linesIterator.toList
+  makeTest("sbt -D arguments")("-Dsbt.supershell=false", "compile", "-v") { out: List[String] =>
     assert(out.contains[String]("-Dsbt.supershell=false"))
-    ()
   }
 
-  test("sbt --sbt-version") {
-    val out = sbtProcess("--sbt-version", "1.3.13", "compile", "-v").!!.linesIterator.toList
+  makeTest("sbt --sbt-version")("--sbt-version", "1.3.13", "-v") { out: List[String] =>
     assert(out.contains[String]("-Dsbt.version=1.3.13"))
-    ()
   }
 
-  test("sbt -mem 503") {
-    val out = sbtProcess("compile", "-mem", "503", "-v").!!.linesIterator.toList
+  makeTest("sbt -mem 503")("-mem", "503", "-v") { out: List[String] =>
     assert(out.contains[String]("-Xmx503m"))
-    ()
   }
 
-  test("sbt with -mem 503, -Xmx in JAVA_OPTS") {
-    val out = sbtProcessWithOpts("compile", "-mem", "503", "-v")("-Xmx1024m", "").!!.linesIterator.toList
+  makeTest("sbt with -mem 503, -Xmx in JAVA_OPTS", javaOpts = "-Xmx1024m")("-mem", "503", "-v") { out: List[String] =>
     assert(out.contains[String]("-Xmx503m"))
     assert(!out.contains[String]("-Xmx1024m"))
-    ()
   }
 
-  test("sbt with -mem 503, -Xmx in SBT_OPTS") {
-    val out = sbtProcessWithOpts("compile", "-mem", "503", "-v")("", "-Xmx1024m").!!.linesIterator.toList
+  makeTest("sbt with -mem 503, -Xmx in SBT_OPTS", sbtOpts = "-Xmx1024m")("-mem", "503", "-v") { out: List[String] =>
     assert(out.contains[String]("-Xmx503m"))
     assert(!out.contains[String]("-Xmx1024m"))
-    ()
   }
 
-  test("sbt with -Xms2048M -Xmx2048M -Xss6M in SBT_OPTS") {
-    val out = sbtProcessWithOpts("compile", "-v")("", "-Xms2048M -Xmx2048M -Xss6M").!!.linesIterator.toList
+  makeTest("sbt with -mem 503, -Xss in JAVA_OPTS", javaOpts = "-Xss6m")("-mem", "503", "-v") { out: List[String] =>
+    assert(out.contains[String]("-Xmx503m"))
+    assert(!out.contains[String]("-Xss6m"))
+  }
+
+  makeTest("sbt with -mem 503, -Xss in SBT_OPTS", sbtOpts = "-Xss6m")("-mem", "503", "-v") { out: List[String] =>
+    assert(out.contains[String]("-Xmx503m"))
+    assert(!out.contains[String]("-Xss6m"))
+  }
+
+  makeTest("sbt with -Xms2048M -Xmx2048M -Xss6M in JAVA_OPTS", javaOpts = "-Xms2048M -Xmx2048M -Xss6M")("-v") { out: List[String] =>
+    assert(out.contains[String]("-Xms2048M"))
+    assert(out.contains[String]("-Xmx2048M"))
     assert(out.contains[String]("-Xss6M"))
-    ()
   }
 
-  test("sbt with -Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080 in SBT_OPTS") {
-    val out = sbtProcessWithOpts("compile", "-v")("", "-Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080").!!.linesIterator.toList
+  makeTest("sbt with -Xms2048M -Xmx2048M -Xss6M in SBT_OPTS", sbtOpts = "-Xms2048M -Xmx2048M -Xss6M")( "-v") { out: List[String] =>
+    assert(out.contains[String]("-Xms2048M"))
+    assert(out.contains[String]("-Xmx2048M"))
+    assert(out.contains[String]("-Xss6M"))
+  }
+
+
+  makeTest(
+    name = "sbt with -Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080 in SBT_OPTS",
+    sbtOpts = "-Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080",
+  )("-v") { out: List[String] =>
     assert(out.contains[String]("-Dhttp.proxyHost=proxy"))
     assert(out.contains[String]("-Dhttp.proxyPort=8080"))
-    ()
   }
 
-  test("sbt with -XX:ParallelGCThreads=16 -XX:PermSize=128M in SBT_OPTS") {
-    val out = sbtProcessWithOpts("compile", "-v")("", "-XX:ParallelGCThreads=16 -XX:PermSize=128M").!!.linesIterator.toList
+  makeTest(
+    name = "sbt with -XX:ParallelGCThreads=16 -XX:PermSize=128M in SBT_OPTS",
+    sbtOpts = "-XX:ParallelGCThreads=16 -XX:PermSize=128M",
+  )("-v") { out: List[String] =>
     assert(out.contains[String]("-XX:ParallelGCThreads=16"))
     assert(out.contains[String]("-XX:PermSize=128M"))
-    ()
   }
 
-  test("sbt with -XX:+UseG1GC -XX:+PrintGC in SBT_OPTS") {
-    val out = sbtProcessWithOpts("compile", "-v")("", "-XX:+UseG1GC -XX:+PrintGC").!!.linesIterator.toList
+  makeTest("sbt with -XX:+UseG1GC -XX:+PrintGC in JAVA_OPTS", javaOpts = "-XX:+UseG1GC -XX:+PrintGC")("-v") { out: List[String] =>
     assert(out.contains[String]("-XX:+UseG1GC"))
     assert(out.contains[String]("-XX:+PrintGC"))
     assert(!out.contains[String]("-XX:+UseG1GC=-XX:+PrintGC"))
-    ()
   }
 
-  test("sbt with -XX:-UseG1GC -XX:-PrintGC in SBT_OPTS") {
-    val out = sbtProcessWithOpts("compile", "-v")("", "-XX:-UseG1GC -XX:-PrintGC").!!.linesIterator.toList
-    assert(out.contains[String]("-XX:-UseG1GC"))
-    assert(out.contains[String]("-XX:-PrintGC"))
-    assert(!out.contains[String]("-XX:-UseG1GC=-XX:-PrintGC"))
-    ()
-  }
-
-  test("sbt with --no-colors in SBT_OPTS") {
-    if (isWindows) cancel("Test not supported on windows")
-    val out = sbtProcessWithOpts("compile", "-v")("", "--no-colors").!!.linesIterator.toList
-    assert(out.contains[String]("-Dsbt.log.noformat=true"))
-    ()
+  makeTest("sbt with -XX:-UseG1GC -XX:-PrintGC in SBT_OPTS", sbtOpts = "-XX:+UseG1GC -XX:+PrintGC")( "-v") { out: List[String] =>
+    assert(out.contains[String]("-XX:+UseG1GC"))
+    assert(out.contains[String]("-XX:+PrintGC"))
+    assert(!out.contains[String]("-XX:+UseG1GC=-XX:+PrintGC"))
   }
 
   test("sbt with -debug in SBT_OPTS appears in sbt commands") {
     if (isWindows) cancel("Test not supported on windows")
 
-    val out: List[String] = sbtProcessWithOpts("compile", "-v")("", "-debug").!!.linesIterator.toList
+    val out: List[String] = sbtProcessWithOpts("compile", "-v")(javaOpts = "", sbtOpts = "-debug").!!.linesIterator.toList
     // Debug argument must appear in the 'commands' section (after the sbt-launch.jar argument) to work
     val sbtLaunchMatcher = """^.+sbt-launch.jar["]{0,1}$""".r
     val locationOfSbtLaunchJarArg = out.zipWithIndex.collectFirst {
@@ -152,24 +155,18 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
     ()
   }
 
-  test("sbt --jvm-debug <port>") {
-    val out = sbtProcess("--jvm-debug", "12345", "compile", "-v").!!.linesIterator.toList
+  makeTest("sbt --jvm-debug <port>")("--jvm-debug", "12345", "-v") { out: List[String] =>
     assert(out.contains[String]("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=12345"))
-    ()
   }
 
-  test("sbt --no-share adds three system properties") {
-    val out = sbtProcess("--no-share").!!.linesIterator.toList
+  makeTest("sbt --no-share adds three system properties")("--no-share") { out: List[String] =>
     assert(out.contains[String]("-Dsbt.global.base=project/.sbtboot"))
     assert(out.contains[String]("-Dsbt.boot.directory=project/.boot"))
     assert(out.contains[String]("-Dsbt.ivy.home=project/.ivy"))
-    ()
   }
 
-  test("accept `--ivy` in `SBT_OPTS`") {
+  makeTest("accept `--ivy` in `SBT_OPTS`", sbtOpts = "--ivy /ivy/dir")("-v") { out: List[String] =>
     if (isWindows) cancel("Test not supported on windows")
-    val out = sbtProcessWithOpts("")("", sbtOpts = "--ivy /ivy/dir").!!.linesIterator.toList
     assert(out.contains[String]("-Dsbt.ivy.home=/ivy/dir"))
-    ()
   }
 }

--- a/src/universal/bin/sbt
+++ b/src/universal/bin/sbt
@@ -154,14 +154,14 @@ addMemory () {
   local xs=("${java_args[@]}")
   java_args=()
   for i in "${xs[@]}"; do
-    if ! [[ "${i}" == *-Xmx* ]] && ! [[ "${i}" == *-Xms* ]] && ! [[ "${i}" == *-XX:MaxPermSize* ]] && ! [[ "${i}" == *-XX:MaxMetaspaceSize* ]] && ! [[ "${i}" == *-XX:ReservedCodeCacheSize* ]]; then
+    if ! [[ "${i}" == *-Xmx* ]] && ! [[ "${i}" == *-Xms* ]] && ! [[ "${i}" == *-Xss* ]] && ! [[ "${i}" == *-XX:MaxPermSize* ]] && ! [[ "${i}" == *-XX:MaxMetaspaceSize* ]] && ! [[ "${i}" == *-XX:ReservedCodeCacheSize* ]]; then
       java_args+=("${i}")
     fi
   done
   local ys=("${sbt_options[@]}")
   sbt_options=()
   for i in "${ys[@]}"; do
-    if ! [[ "${i}" == *-Xmx* ]] && ! [[ "${i}" == *-Xms* ]] && ! [[ "${i}" == *-XX:MaxPermSize* ]] && ! [[ "${i}" == *-XX:MaxMetaspaceSize* ]] && ! [[ "${i}" == *-XX:ReservedCodeCacheSize* ]]; then
+    if ! [[ "${i}" == *-Xmx* ]] && ! [[ "${i}" == *-Xms* ]] && ! [[ "${i}" == *-Xss* ]] && ! [[ "${i}" == *-XX:MaxPermSize* ]] && ! [[ "${i}" == *-XX:MaxMetaspaceSize* ]] && ! [[ "${i}" == *-XX:ReservedCodeCacheSize* ]]; then
       sbt_options+=("${i}")
     fi
   done
@@ -187,6 +187,7 @@ addDefaultMemory() {
   # The reason is the Xms/Xmx, if they don't line up, cause errors.
   if [[ "${java_args[@]}" == *-Xmx* ]] || \
      [[ "${java_args[@]}" == *-Xms* ]] || \
+     [[ "${java_args[@]}" == *-Xss* ]] || \
      [[ "${java_args[@]}" == *-XX:+UseCGroupMemoryLimitForHeap* ]] || \
      [[ "${java_args[@]}" == *-XX:MaxRAM* ]] || \
      [[ "${java_args[@]}" == *-XX:InitialRAMPercentage* ]] || \
@@ -195,6 +196,7 @@ addDefaultMemory() {
     :
   elif [[ "${JAVA_TOOL_OPTIONS}" == *-Xmx* ]] || \
        [[ "${JAVA_TOOL_OPTIONS}" == *-Xms* ]] || \
+       [[ "${JAVA_TOOL_OPTIONS}" == *-Xss* ]] || \
        [[ "${JAVA_TOOL_OPTIONS}" == *-XX:+UseCGroupMemoryLimitForHeap* ]] || \
        [[ "${JAVA_TOOL_OPTIONS}" == *-XX:MaxRAM* ]] || \
        [[ "${JAVA_TOOL_OPTIONS}" == *-XX:InitialRAMPercentage* ]] || \
@@ -203,6 +205,7 @@ addDefaultMemory() {
     :
   elif [[ "${sbt_options[@]}" == *-Xmx* ]] || \
        [[ "${sbt_options[@]}" == *-Xms* ]] || \
+       [[ "${sbt_options[@]}" == *-Xss* ]] || \
        [[ "${sbt_options[@]}" == *-XX:+UseCGroupMemoryLimitForHeap* ]] || \
        [[ "${sbt_options[@]}" == *-XX:MaxRAM* ]] || \
        [[ "${sbt_options[@]}" == *-XX:InitialRAMPercentage* ]] || \

--- a/src/universal/bin/sbt.bat
+++ b/src/universal/bin/sbt.bat
@@ -726,7 +726,7 @@ exit /B 0
   if "!_old_java_opts!" == "" goto :done_java_opt
   for /F "tokens=1,*" %%g in ("!_old_java_opts!") do (
     set "p=%%g"
-    if not "!p:~0,4!" == "-Xmx" if not "!p:~0,4!" == "-Xms" if not "!p:~0,15!" == "-XX:MaxPermSize" if not "!p:~0,20!" == "-XX:MaxMetaspaceSize" if not "!p:~0,25!" == "-XX:ReservedCodeCacheSize" (
+    if not "!p:~0,4!" == "-Xmx" if not "!p:~0,4!" == "-Xms" if not "!p:~0,4!" == "-Xss" if not "!p:~0,15!" == "-XX:MaxPermSize" if not "!p:~0,20!" == "-XX:MaxMetaspaceSize" if not "!p:~0,25!" == "-XX:ReservedCodeCacheSize" (
       set _new_java_opts=!_new_java_opts! %%g
     )
     set "_old_java_opts=%%h"
@@ -741,7 +741,7 @@ exit /B 0
   if "!_old_sbt_opts!" == "" goto :done_sbt_opt
   for /F "tokens=1,*" %%g in ("!_old_sbt_opts!") do (
     set "p=%%g"
-    if not "!p:~0,4!" == "-Xmx" if not "!p:~0,4!" == "-Xms" if not "!p:~0,15!" == "-XX:MaxPermSize" if not "!p:~0,20!" == "-XX:MaxMetaspaceSize" if not "!p:~0,25!" == "-XX:ReservedCodeCacheSize" (
+    if not "!p:~0,4!" == "-Xmx" if not "!p:~0,4!" == "-Xms" if not "!p:~0,4!" == "-Xss" if not "!p:~0,15!" == "-XX:MaxPermSize" if not "!p:~0,20!" == "-XX:MaxMetaspaceSize" if not "!p:~0,25!" == "-XX:ReservedCodeCacheSize" (
       set _new_sbt_opts=!_new_sbt_opts! %%g
     )
     set "_old_sbt_opts=%%h"
@@ -779,18 +779,21 @@ exit /B 0
     set "p=%%g"
     if "!p:~0,4!" == "-Xmx" set _has_memory_args=1
     if "!p:~0,4!" == "-Xms" set _has_memory_args=1
+    if "!p:~0,4!" == "-Xss" set _has_memory_args=1
   )
 
   if defined JAVA_TOOL_OPTIONS for /F %%g in ("%JAVA_TOOL_OPTIONS%") do (
     set "p=%%g"
     if "!p:~0,4!" == "-Xmx" set _has_memory_args=1
     if "!p:~0,4!" == "-Xms" set _has_memory_args=1
+    if "!p:~0,4!" == "-Xss" set _has_memory_args=1
   )
 
   if defined _SBT_OPTS for /F %%g in ("!_SBT_OPTS!") do (
     set "p=%%g"
     if "!p:~0,4!" == "-Xmx" set _has_memory_args=1
     if "!p:~0,4!" == "-Xms" set _has_memory_args=1
+    if "!p:~0,4!" == "-Xss" set _has_memory_args=1
   )
 
   if not defined _has_memory_args (


### PR DESCRIPTION
## before

```
> cat .jvmopts
cat .jvmopts
-Dfile.encoding=UTF8
-Xms1G
-Xmx5G
-Xss6M
-XX:ReservedCodeCacheSize=512m
-XX:+UseG1GC

❯ sbt -d -mem 5632 'testOnly foo'
[addSbt] arg = '-debug'
[addMemory] arg = '5632'
[addJava] arg = '-Xms5632m'
[addJava] arg = '-Xmx5632m'
[addJava] arg = '-Xss4M'
[addJava] arg = '-XX:ReservedCodeCacheSize=512m'
...
# Executing command line:
java
-Dfile.encoding=UTF8
-Xss6M
-XX:+UseG1GC
-Xms5632m
-Xmx5632m
-Xss4M
-XX:ReservedCodeCacheSize=512m
-jar
/Users/eric/.sdkman/candidates/sbt/1.4.6/bin/sbt-launch.jar
-debug
```

## after

```
❯ cat .jvmopts
-Dfile.encoding=UTF8
-Xms1G
-Xmx5G
-Xss6M
-XX:ReservedCodeCacheSize=512m
-XX:+UseG1GC
❯ sbt -d -mem 5632 'testOnly foo'
[addSbt] arg = '-debug'
[addMemory] arg = '5632'
[addJava] arg = '-Xms5632m'
[addJava] arg = '-Xmx5632m'
[addJava] arg = '-Xss4M'
[addJava] arg = '-XX:ReservedCodeCacheSize=512m'
...
# Executing command line:
java
-Dfile.encoding=UTF8
-XX:+UseG1GC
-Xms5632m
-Xmx5632m
-Xss4M
-XX:ReservedCodeCacheSize=512m
-jar
/Users/eric/.sdkman/candidates/sbt/1.4.6/bin/sbt-launch.jar
-debug
```